### PR TITLE
Allow configurable dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ well for the majority of the OCaml projects and provides a convenient way to
 add benchmarking.
 
 <details>
-<summary>Default Dockerfile for opam projects: </summary>
+<summary>Default Dockerfile for opam projects.</summary>
 
 ```
 FROM ocurrent/opam

--- a/README.md
+++ b/README.md
@@ -64,6 +64,50 @@ dune exec bin/main.exe -- github mirage/index \
 
 You can find more options for different configurations, posting message to slack, etc by running `--help` to the pipeline executable.
 
+### Customising the Docker image
+
+The pipeline executes the benchmarking targets in docker containers. The
+default docker image used for this is specialised for opam projects. This works
+well for the majority of the OCaml projects and provides a convenient way to
+add benchmarking.
+
+<details>
+<summary>Default Dockerfile for opam projects: </summary>
+
+```
+FROM ocurrent/opam
+
+RUN sudo apt-get update && sudo apt-get install -qq -yy libffi-dev \
+  liblmdb-dev m4 pkg-config gnuplot-x11 libgmp-dev libssl-dev
+
+COPY --chown=opam:opam . bench-dir
+WORKDIR bench-dir
+RUN opam install -y --deps-only -t .
+ADD --chown=opam . .
+RUN eval $(opam env)
+```
+
+</details>
+
+In some situations, the provided docker environment needed to run the
+benchmarks might not be sufficient. Users of the piepline can provide
+a custom dockerfile as a command-line argument:
+
+```
+dune exec bin/main.exe -- local "/home/user/repos/mirage/index" \
+    --dockerfile "bench.docker"
+    --docker-cpu 3 \
+    --conn-info "host=localhost user=docker port=5432 dbname=docker password=docker" \
+    --port=8081 \
+    --verbose
+```
+
+The path of the docker file is resolved relative to the project's root directory.
+
+> Note: the dockerfile **must not** set an entrypoint. Currently `make bench`
+> is executed to run the benchmarks.
+
+
 ### Benchmarks format
 
 If you want to enroll your repository or setup this benchmark repository for your repository,

--- a/backend/bin/main.ml
+++ b/backend/bin/main.ml
@@ -58,6 +58,10 @@ module Docker = struct
     let doc = "Size of tmpfs volume to be mounted in /dev/shm (in GB)." in
     Arg.(value & opt int 4 & info [ "docker-shm-size" ] ~doc)
 
+  let dockerfile =
+    let doc = "Relative path to the custom Dockerfile used for benchmarking." in
+    Arg.(value & opt (some path) None & info [ "dockerfile" ] ~doc)
+
   let v =
     Term.(
       const (fun cpu numa_node shm_size ->
@@ -81,11 +85,14 @@ let conninfo =
 
 let cmd : (Pipeline.Source.t -> (unit, [ `Msg of string ]) result) Term.t =
   Term.(
-    const (fun current_config server docker_config conninfo () source ->
-        Pipeline.v ~current_config ~docker_config ~server ~source conninfo ())
+    const
+      (fun current_config server docker_config dockerfile conninfo () source ->
+        Pipeline.v ~current_config ~docker_config ?dockerfile ~server ~source
+          conninfo ())
     $ Current.Config.cmdliner
     $ Current_web.cmdliner
     $ Docker.v
+    $ Docker.dockerfile
     $ conninfo
     $ setup_log)
 

--- a/backend/lib/pipeline.mli
+++ b/backend/lib/pipeline.mli
@@ -21,6 +21,7 @@ end
 val v :
   current_config:Current.Config.t ->
   docker_config:Docker_config.t ->
+  ?dockerfile:Fpath.t ->
   server:Conduit_lwt_unix.server ->
   source:Source.t ->
   string ->


### PR DESCRIPTION
Addresses https://github.com/ocurrent/current-bench/issues/11.

### Changes
1. The an optional `dockerfile: Fpath.t` argument is added to `Pipeline.v`.
    - If provided, the pipeline will attempt to build a custom docker image from the referenced file.
    - If not provided, the existing functionality is used, ,i.e., use the default dockerfile for opam projects.
2. The main binary is updated to expose the `--dockerfile` option.
3. The README is updated to describe the new functionality.