### PR TITLE
Allow configurable benchmark targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can find more options for different configurations, posting message to slack
 If you want to enroll your repository or setup this benchmark repository for your repository,
 we make the following assumptions.
 
-1. There is a dune bench target which can run the benchmarks.
+1. There is a `make bench` target which can run the benchmarks.
 2. The benchmarks results are json with of the following format:
 ```
 {
@@ -89,6 +89,17 @@ we make the following assumptions.
 [Here's](https://gist.github.com/gs0510/9ef5d47582b7fbf8dda6df0af08537e4) an example from [index](https://github.com/mirage/index) with regards to what the format looks like.
 
 The metadata about `repo`, `branch` and `commit` is added by the pipeline. Your repo only needs to output the results as a json.
+
+#### Custom benchmark command
+
+The default benchmarking command executed in the docker container is:
+
+```
+/usr/bin/setarch x86_64 --addr-no-randomize make bench
+```
+
+This can be overriden by the `cmd` option in the pipeline executable. See the `--help` output for details.
+
 
 ### Starting a graphql engine connected to the Postgres Database
 

--- a/backend/bin/main.ml
+++ b/backend/bin/main.ml
@@ -7,7 +7,7 @@ let cmd_conv =
     let res = Bos.Cmd.of_string str in
     Result.map Bos.Cmd.to_list res
   in
-  let pp ppf cmd = Bos.Cmd.(Bos.Cmd.pp ppf (of_list cmd)) in
+  let pp ppf cmd = Bos.Cmd.(pp ppf (of_list cmd)) in
   Arg.conv ~docv:"CMD" (of_string, pp)
 
 module Source = struct

--- a/backend/bin/main.ml
+++ b/backend/bin/main.ml
@@ -58,6 +58,12 @@ module Docker = struct
     let doc = "Size of tmpfs volume to be mounted in /dev/shm (in GB)." in
     Arg.(value & opt int 4 & info [ "docker-shm-size" ] ~doc)
 
+  let cmd =
+    let doc =
+      "The command used to start the benchmarks in the docker container."
+    in
+    Arg.(value & opt (some string) None & info [ "cmd" ] ~doc)
+
   let v =
     Term.(
       const (fun cpu numa_node shm_size ->
@@ -81,11 +87,13 @@ let conninfo =
 
 let cmd : (Pipeline.Source.t -> (unit, [ `Msg of string ]) result) Term.t =
   Term.(
-    const (fun current_config server docker_config conninfo () source ->
-        Pipeline.v ~current_config ~docker_config ~server ~source conninfo ())
+    const (fun current_config server docker_config cmd conninfo () source ->
+        Pipeline.v ~current_config ~docker_config ?cmd ~server ~source conninfo
+          ())
     $ Current.Config.cmdliner
     $ Current_web.cmdliner
     $ Docker.v
+    $ Docker.cmd
     $ conninfo
     $ setup_log)
 

--- a/backend/bin/main.ml
+++ b/backend/bin/main.ml
@@ -2,6 +2,14 @@ open Cmdliner
 
 let path = Arg.conv ~docv:"PATH" Fpath.(of_string, pp)
 
+let cmd_conv =
+  let of_string str =
+    let res = Bos.Cmd.of_string str in
+    Result.map Bos.Cmd.to_list res
+  in
+  let pp ppf cmd = Bos.Cmd.(Bos.Cmd.pp ppf (of_list cmd)) in
+  Arg.conv ~docv:"CMD" (of_string, pp)
+
 module Source = struct
   let github =
     let repo =
@@ -62,7 +70,7 @@ module Docker = struct
     let doc =
       "The command used to start the benchmarks in the docker container."
     in
-    Arg.(value & opt (some string) None & info [ "cmd" ] ~doc)
+    Arg.(value & opt (some cmd_conv) None & info [ "cmd" ] ~docv:"CMD" ~doc)
 
   let v =
     Term.(

--- a/backend/lib/pipeline.ml
+++ b/backend/lib/pipeline.ml
@@ -48,7 +48,7 @@ let dockerfile ~base =
   @@ run "eval $(opam env)"
 
 let default_docker_cmd =
-  "/usr/bin/setarch x86_64 --addr-no-randomize make bench"
+  [ "/usr/bin/setarch"; "x86_64"; "--addr-no-randomize"; "make"; "bench" ]
 
 let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) ()
 
@@ -85,8 +85,7 @@ let pipeline ~slack_path ~conninfo ~(info : pr_info) ~dockerfile ~cmd ~tmpfs
       @ docker_cpuset_cpus
       @ docker_cpuset_mems
     in
-    let+ output =
-      Docker.pread ~run_args image ~args:(String.split_on_char ' ' cmd)
+    let+ output = Docker.pread ~run_args image ~args:cmd
     and+ commit =
       match head with
       | `Github api_commit -> Current.return (Github.Api.Commit.hash api_commit)

--- a/backend/lib/pipeline.mli
+++ b/backend/lib/pipeline.mli
@@ -21,7 +21,7 @@ end
 val v :
   current_config:Current.Config.t ->
   docker_config:Docker_config.t ->
-  ?cmd:string ->
+  ?cmd:string list ->
   server:Conduit_lwt_unix.server ->
   source:Source.t ->
   string ->

--- a/backend/lib/pipeline.mli
+++ b/backend/lib/pipeline.mli
@@ -21,6 +21,7 @@ end
 val v :
   current_config:Current.Config.t ->
   docker_config:Docker_config.t ->
+  ?cmd:string ->
   server:Conduit_lwt_unix.server ->
   source:Source.t ->
   string ->


### PR DESCRIPTION
Addresses https://github.com/ocurrent/current-bench/issues/10.

Currently the assumption is made that the repository to be benchmarked has a `Makefile` with the `bench` target. It should be possible to alter this configuration for projects that follow a different existing convention.

This PR implements a simple approach to overriding the default command executed to start the benchmarks in the docker environment. This change is done via a command-line option that persists for the execution of the pipeline.

This has some limitations and presents a challenge for current-bench in deciding _when_ this should be allowed.


## Execution stages

Providing a simple user experience while working with benchmarks requires a very careful management of conventions and expectations. On the one hand our infrastructure could offer a "zero-config" service that "just works", on the other hand we could allow users to customise the different aspects of the execution of the benchmarks and the pipeline itself.

Configurability and the "zero-config" experience are not mutually exclusive. In fact, "zero-config" can be achieved with a good selection of default configuration options.

Both https://github.com/ocurrent/current-bench/issues/11 and https://github.com/ocurrent/current-bench/issues/10 add configurability to the benchmarking infrastructure. It is important to understand what this means for the benchmarking service and for the users.

From the point of view of opportunities to customise the behaviour of the benchmarks the following stages can be outlined:

1. **Pipeline initialisation time**: the main executable is started allowing to provide multiple command-line options. The provided options (normally) do not change during the execution of the pipeline. This configuration is mostly useful for pipeline instances dedicated for specific usage or for local execution.
2. **GitHub App is added to a repo**: an existing instance  of the pipeline (pre-configured as in 1) is set up for a new GitHub project to be benchmarked. When adding the app GitHub can redirect the users to a page to provide some additional configuration. On this page users could provide their preferred configuration for the app. This could include defining the benchmark target, for example.
3. **Automated execution (on commit)**: when the pipeline schedules the execution of a new benchmark, the source code of the project can contain a configuration file that can be used by the pipeline to customise the execution behaviour. This allows dynamic changes that are not possible with 1 and 2, with the commit-level granularity. For example, if users want to change the benchmarking target in a specific commit, it should be possible during this stage.
4. **Manual trigger**: works by allowing users to trigger the (re)execution of benchmarks on demand. This functionality might require some more advanced integration between the app and the repo to allow something like `/benchmark` commands in Github comments, for example. When executing the benchmark this way, users could provide additional parameters, such as the benchmarking targets. One particularly interesting use case is supporting `quick` and `slow` targets, similar to how this is implement in Alcotest.

Further analysis of requirements for simple and more complex projects is required to decide what configurations (and when!) should be possible.

## Summary

The current PR takes a conservative approach and implements the configuration to override the benchmarking command at the "Pipeline initialisation time", allowing different pipeline instances to support different targets. This might not be an ideal approach; additional usage requirements would help make a better decision.