### PR TITLE
Read multiple JSON objects from benchmark output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ You can find more options for different configurations, posting message to slack
 If you want to enroll your repository or setup this benchmark repository for your repository,
 we make the following assumptions.
 
-1. There is a dune bench target which can run the benchmarks.
+1. There is a `make bench` target which can run the benchmarks.
 2. The benchmarks results are json with of the following format:
 ```
 {
   "results" : [
     {
-      "name": <name-of-the-benchmarks>,
+      "name": <name-of-the-test>,
       "metrics": {
         "<metric-1>": "",
         "<metric2>": "",
@@ -86,6 +86,9 @@ we make the following assumptions.
   ]
 }
 ```
+
+> Note: multiple concatenated JSON objects can be produced and will be interpreted as different benchmarks. The names of the benchmark test must be unique across the benchmark results.
+
 [Here's](https://gist.github.com/gs0510/9ef5d47582b7fbf8dda6df0af08537e4) an example from [index](https://github.com/mirage/index) with regards to what the format looks like.
 
 The metadata about `repo`, `branch` and `commit` is added by the pipeline. Your repo only needs to output the results as a json.

--- a/backend/lib/pipeline.ml
+++ b/backend/lib/pipeline.ml
@@ -93,19 +93,23 @@ let pipeline ~slack_path ~conninfo ~(info : pr_info) ~dockerfile ~tmpfs
       | `Github api_commit -> Current.return (Github.Api.Commit.hash api_commit)
       | `Local commit -> commit >>| Git.Commit.hash
     in
-    let content = Utils.merge_json ~repo:name ~owner ~commit output in
-    let () =
-      let pr_info = string_pr_info owner name info in
-      Utils.populate_postgres ~conninfo ~commit ~json_string:content ~pr_info
-    in
-    match slack_path with Some p -> Some (p, content) | None -> None
+    let results = Utils.merge_json ~repo:name ~owner ~commit output in
+    List.iter
+      (fun json_string ->
+        let pr_info = string_pr_info owner name info in
+        Utils.populate_postgres ~conninfo ~commit ~json_string ~pr_info)
+      results;
+    match slack_path with Some p -> Some (p, results) | None -> None
   in
   s
   |> Current.option_map (fun p ->
          Current.component "post"
          |> let** path, _ = p in
             let channel = read_channel_uri path in
-            Slack.post channel ~key:"output" (p >>| snd))
+            let results =
+              Current.map (fun (_, results) -> String.concat "\n" results) p
+            in
+            Slack.post channel ~key:"output" results)
   |> Current.state
   |> fun result ->
   match head with

--- a/backend/lib/utils.ml
+++ b/backend/lib/utils.ml
@@ -18,9 +18,9 @@ let construct_data_for_benchmarks_run commit json pr_str =
     List.map2
       (fun json bench_name ->
         let metrics = json |> member "metrics" in
-        let time = metrics |> member "time" |> to_float in
-        let mbs_per_sec = metrics |> member "mbs_per_sec" |> to_float in
-        let ops_per_sec = metrics |> member "ops_per_sec" |> to_float in
+        let time = metrics |> member "time" |> to_number in
+        let mbs_per_sec = metrics |> member "mbs_per_sec" |> to_number in
+        let ops_per_sec = metrics |> member "ops_per_sec" |> to_number in
         Fmt.str "('%s', '%s', %f, %f, %f, %f, '%s')" commit bench_name time
           mbs_per_sec ops_per_sec (Unix.time ()) pr_str)
       bench_objects bench_names
@@ -69,7 +69,7 @@ let populate_postgres ~conninfo ~commit ~json_string ~pr_info =
     let _ =
       c#exec ~expect:[ Command_ok ]
         ("insert into benchmarksrun(commits, name, time, mbs_per_sec, \
-          ops_per_sec, timestamp, branch) values "
+           ops_per_sec, timestamp, branch) values "
         ^ data_to_insert)
     in
     c#finish

--- a/backend/lib/utils.mli
+++ b/backend/lib/utils.mli
@@ -1,7 +1,10 @@
 val read_fpath : Fpath.t -> string
 
 val merge_json :
-  repo:string -> owner:string -> commit:string -> string -> string
+  repo:string -> owner:string -> commit:string -> string -> string list
+(** [merge_json ~repo ~owner ~commit multi_json] is a list of JSON strings
+    containing benchmarking results for a given [repo], [owner] and [commit].
+    The results are obtained from the multi-object [multi_json] string. *)
 
 val populate_postgres :
   conninfo:string ->

--- a/backend/postgres/init.sql
+++ b/backend/postgres/init.sql
@@ -2,7 +2,7 @@ GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
 
 CREATE TABLE benchmarks(
 	repositories varchar(256),
-	commits varchar(50) NOT NULL UNIQUE,
+	commits varchar(50) NOT NULL,
 	json_data jsonb,
 	timestamp float8,
 	branch varchar(256)


### PR DESCRIPTION
Implementation of https://github.com/ocurrent/current-bench/pull/13#issuecomment-746279444.

The changes to support multiple JSON objects in the benchmark output is pretty simple. The problematic part is knowing how to merge the multiple results. The current SQL schema disallows multiple entries per commit. I think there are two solutions to this:

1. Add an additional column to the SQL schema for benchmarks table. This would represent the unique name of the benchmark for a given repo and commit. The JSON format should be updated to have a top-level `name` key in this case.
2. Merge the individual entries under `results` in the JSON output and only insert one results object into the database per commit. This does not require changes to the JSON output format, but requires that the result "names" are unique across different benchmarks.

I'm leaning towards supporting multiple benchmarks per repo/commit, i.e., 1.