### PR TITLE
Temporary use remote opam repo.

### DIFF
--- a/backend/lib/pipeline.ml
+++ b/backend/lib/pipeline.ml
@@ -43,6 +43,7 @@ let dockerfile ~base =
         liblmdb-dev m4 pkg-config gnuplot-x11 libgmp-dev libssl-dev"
   @@ copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir" ()
   @@ workdir "bench-dir"
+  @@ run "opam remote add origin https://opam.ocaml.org"
   @@ run "opam install -y --deps-only -t ."
   @@ add ~src:[ "--chown=opam ." ] ~dst:"." ()
   @@ run "eval $(opam env)"


### PR DESCRIPTION
Temporary fix for https://github.com/ocurrent/current-bench/issues/15.

It seems like the base image is out of date and does not contain the latest version of the opam repository.

Ideally the base image should always be up to date, in which case using the remote repo won't be necessary.