### PR TITLE
Minor deployment fixes

### DIFF
--- a/backend/current-bench.service
+++ b/backend/current-bench.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OCaml Benchmarks Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+User=current-bench
+Type=oneshot
+RemainAfterExit=true
+WorkingDirectory=/home/current-bench/
+ExecStart=/usr/bin/docker-compose up -d --remove-orphans
+ExecStop=/usr/bin/docker-compose down
+
+[Install]
+WantedBy=multi-user.target

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       context: ${FRONTEND_DIRECTORY}
       dockerfile: Dockerfile
     ports:
-    - "3000:82"
+    - "80:80"
     restart: always
        
 volumes:

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - POSTGRES_PASSWORD=docker
     restart: always
     volumes:
-    - ./db_data:/var/lib/postgresql/data
+    - db_data:/var/lib/postgresql/data
     ports: ["5432:5432"]
   graphql-engine:
     image: hasura/graphql-engine:v1.2.2

--- a/frontend-new/etc/nginx.conf
+++ b/frontend-new/etc/nginx.conf
@@ -1,0 +1,15 @@
+worker_processes 4;
+
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+        root  /usr/share/nginx/html;
+        include /etc/nginx/mime.types;
+
+        location /appui {
+            try_files $uri public/index.html;
+        }
+    }
+}


### PR DESCRIPTION
Preparatory fixes for deployment.

My plan is to allow starting the entire current-bench infrastructure with a single `systemctl start current-bench` on our deployment machine.

This PR:

- Adds the systemd init file;
- Fixes a volume mount to use the docker volume instead of a local folder;
- Adds the nginx config file from the old frontend;
- Changes the port number for the UI from 82 to 80 inside the container and from 3000 to 80 externally.

I'm planning on creating a `current-bench` user on `autumn` to have a dedicated environment for deployments. Any objections to that?