### PR TITLE
Benchmarks table migration

### DIFF
--- a/backend/db/migrations/20210013150054_add_benchmarks_table.up.sql
+++ b/backend/db/migrations/20210013150054_add_benchmarks_table.up.sql
@@ -1,10 +1,9 @@
-CREATE TABLE benchmarks(
-    run_at timestamp without time zone not null,
-	duration interval NOT NULL,
-	repo_id varchar(256) NOT NULL,
-	commit varchar(50) NOT NULL,
-	branch varchar(256),
-	pull_number integer,
-	name varchar(256),
-	data jsonb
-);
+	CREATE TABLE benchmarks(
+		run_at timestamp without time zone not null,
+		repo_id varchar(256) NOT NULL,
+		commit varchar(50) NOT NULL,
+		branch varchar(256),
+		pull_number integer,
+		name varchar(256),
+		metrics jsonb
+	);

--- a/backend/postgres/init.sql
+++ b/backend/postgres/init.sql
@@ -1,13 +1,5 @@
 GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
 
-CREATE TABLE benchmarks(
-	repositories varchar(256),
-	commits varchar(50) NOT NULL,
-	json_data jsonb,
-	timestamp float8,
-	branch varchar(256)
-);
-
 CREATE TABLE benchmarksrun (
     commits varchar(50),
     name varchar(100),

--- a/backend/utils/benchmarksrun_to_benchmarks.sql
+++ b/backend/utils/benchmarksrun_to_benchmarks.sql
@@ -1,0 +1,28 @@
+
+-- Populates the benchmarks table with all the records from benchmarksrun.
+BEGIN;
+INSERT INTO
+    benchmarks(run_at, repo_id, commit, branch, pull_number, name, metrics)
+SELECT
+    to_timestamp(timestamp) AS run_at,
+    split_part(branch, '/', 1) || '/' || split_part(branch, '/', 2)  AS repo_id,
+    commits AS commit,
+    CASE
+    WHEN not (split_part(branch, '/', 3) ~ '^[0-9]+$') THEN
+        split_part(branch, '/', 3)
+    ELSE
+        NULL
+    END AS branch,
+    CASE
+    WHEN split_part(branch, '/', 3) ~ '^[0-9]+$' THEN
+        split_part(branch, '/', 3)::integer
+    ELSE
+        NULL
+    END AS pull_number,
+    NULL AS name,
+    ('{"time":' || time ||
+    ', "ops_per_sec":' || ops_per_sec || 
+    ', "mbs_per_sec":' || mbs_per_sec || '}')::jsonb AS metrics
+FROM
+    benchmarksrun;
+COMMIT;


### PR DESCRIPTION
Adds an SQL migration script I'm planning on running in production to copy all the records from `benchmarksrun` to `benchmarks`.

Just a reminder that this is done to allow for arbitrary metrics to be stored given that `benchmarksrun` has only three hardcoded metric columns.