### PR TITLE
Dockerized build environment for the backend.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: ci
+ci:
+	make -C backend docker-build
+	make -C backend docker-install

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -16,3 +16,12 @@ db-migrate-up:
 .PHONY: db-migrate-down
 db-migrate-down:
 	omigrate down --verbose --source=${DB_MIGRATIONS_DIR} --database=${DB_URI}
+
+.PHONY: build
+build:
+	dune build --profile=release bin/main.exe
+
+.PHONY: docker-build
+docker-build:
+	docker build -t current-bench-pipeline-build -f build.docker .
+	docker run -it -v $$PWD/_build/_docker:/mnt/export current-bench-pipeline-build

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -27,8 +27,7 @@ _build/_docker/current-bench-pipeline:
 	docker build -t current-bench-pipeline-build -f build.docker .
 	docker run -it -v $$PWD/_build/_docker:/mnt/export current-bench-pipeline-build
 
-PREFIX := /usr/local/bin
+PREFIX ?= /usr/local/bin
 .PHONY: docker-install
 docker-install: _build/_docker/current-bench-pipeline
-	mkdir -p $(PREFIX)
-	cp _build/_docker/current-bench-pipeline $(PREFIX)/current-bench-pipeline
+	cp _build/_docker/current-bench-pipeline ${PREFIX}/current-bench-pipeline

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -22,6 +22,13 @@ build:
 	dune build --profile=release bin/main.exe
 
 .PHONY: docker-build
-docker-build:
+docker-build: _build/_docker/current-bench-pipeline
+_build/_docker/current-bench-pipeline:
 	docker build -t current-bench-pipeline-build -f build.docker .
 	docker run -it -v $$PWD/_build/_docker:/mnt/export current-bench-pipeline-build
+
+PREFIX := /usr/local/bin
+.PHONY: docker-install
+docker-install: _build/_docker/current-bench-pipeline
+	mkdir -p $(PREFIX)
+	cp _build/_docker/current-bench-pipeline $(PREFIX)/current-bench-pipeline

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -24,8 +24,8 @@ build:
 .PHONY: docker-build
 docker-build: _build/_docker/current-bench-pipeline
 _build/_docker/current-bench-pipeline:
-	docker build -t current-bench-pipeline-build -f build.docker .
-	docker run -it -v $$PWD/_build/_docker:/mnt/export current-bench-pipeline-build
+	export DOCKER_BUILDKIT=1 \
+	docker build --target=export --output="type=local,dest=$$PWD/_build/_docker" -f build.docker .
 
 PREFIX ?= /usr/local/bin
 .PHONY: docker-install

--- a/backend/build.docker
+++ b/backend/build.docker
@@ -1,0 +1,30 @@
+FROM ocaml/opam
+
+RUN sudo apt-get update && \
+    sudo apt-get install -qq -yy \
+    libffi-dev \
+    m4 \
+    pkg-config \
+    libssl-dev \
+    libgmp-dev \
+    libpq-dev \
+    capnproto \
+    libsqlite3-dev \
+    libcapnp-dev
+
+WORKDIR /mnt/project
+
+# Build dependencies.
+COPY --chown=opam:opam pipeline.opam pipeline.opam
+RUN opam install -y --deps-only -t .
+COPY --chown=opam . .
+
+# Build the project.
+RUN opam exec -- dune build --profile=release bin/main.exe
+
+# Export the target.
+# The produced pipeline needs to be run natively to be able to build and run
+# docker containers. We simply copy the executable produced during the build
+# to the mounted export folder.
+VOLUME /mnt/export
+CMD cp /mnt/project/_build/default/bin/main.exe /mnt/export/current-bench-pipeline

--- a/backend/build.docker
+++ b/backend/build.docker
@@ -1,4 +1,4 @@
-FROM ocaml/opam
+FROM ocaml/opam as build
 
 RUN sudo apt-get update && \
     sudo apt-get install -qq -yy \
@@ -8,6 +8,7 @@ RUN sudo apt-get update && \
     libssl-dev \
     libgmp-dev \
     libpq-dev \
+    graphviz \
     capnproto \
     libsqlite3-dev \
     libcapnp-dev
@@ -22,9 +23,6 @@ COPY --chown=opam . .
 # Build the project.
 RUN opam exec -- dune build --profile=release bin/main.exe
 
-# Export the target.
-# The produced pipeline needs to be run natively to be able to build and run
-# docker containers. We simply copy the executable produced during the build
-# to the mounted export folder.
-VOLUME /mnt/export
-CMD cp /mnt/project/_build/default/bin/main.exe /mnt/export/current-bench-pipeline
+# Export targets.
+FROM scratch as export
+COPY --from=build /mnt/project/_build/default/bin/main.exe /

--- a/current-bench-app.service
+++ b/current-bench-app.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=OCaml Benchmarks Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+User=current-bench
+Type=oneshot
+RemainAfterExit=true
+WorkingDirectory=/home/current-bench/
+ExecStart=/usr/bin/docker-compose \
+    -f /home/current-bench/src/current-bench/docker-compose.yaml \
+    up -d --remove-orphans
+ExecStop=/usr/bin/docker-compose down
+
+[Install]
+WantedBy=multi-user.target

--- a/current-bench-pipeline.service
+++ b/current-bench-pipeline.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=OCaml Benchmarks Pipeline
+Requires=docker.service
+After=docker.service
+
+[Service]
+User=current-bench
+Type=oneshot
+RemainAfterExit=true
+WorkingDirectory=/home/current-bench/
+ExecStart=/home/current-bench/bin/current-bench-pipeline github_app \
+    --github-app-id=$GITHUB_APP_ID \
+    --github-account-whitelist=mirage \
+    --github-private-key-file=$PATH_TO_PEM \
+    --docker-cpu=3 \
+    --conn-info="host=localhost user=docker port=5432 dbname=docker password=$DB_PASSWD" \
+    --port=8081 \
+    --verbose
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   postgres:
-    build: ./postgres
+    build: ./backend/postgres
     environment:
     - POSTGRES_DB=docker
     - POSTGRES_USER=docker
@@ -23,9 +23,7 @@ services:
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_ADMIN_SECRET: ${GRAPHQL_KEY}
   frontend:
-    build:
-      context: ${FRONTEND_DIRECTORY}
-      dockerfile: Dockerfile
+    build: ./frontend
     ports:
     - "80:80"
     restart: always


### PR DESCRIPTION
This will allow us to build the pipeline on autumn (i.e., the deployment environment) without relying on the local opam configuration.

Note that the pipeline can be _built_ with docker but it cannot be _run_ with docker because the resulting executable invokes docker to build and run images natively. We could at some point look into [running docker in docker](https://www.docker.com/blog/docker-can-now-run-within-docker/), but for now the resulting executable is copied into a mounted host folder.