### PR TITLE
select repository and sync with url

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -215,57 +215,54 @@ let make = () => {
         let selectedRepo = repos->Belt.Array.getBy(repo => repo == orgName ++ "/" ++ repoName)
         switch selectedRepo {
         | None => <div> {"This repo does not exist!"->Rx.string} </div>
-        | Some(selectedRepo) => {
-            let benchmarksForRepo = collectBenchmarksForRepo(~repo=selectedRepo, benchmarks)
-            let pullsForRepo = collectPullsForRepo(~repo=selectedRepo, benchmarks)
-            switch rest {
-            | list{"pull", pullNumberStr} =>
-              switch Belt.Int.fromString(pullNumberStr) {
-              | None =>
-                <div>
-                  {("Pull request must be an integer. Got: " ++ pullNumberStr)->Rx.string}
-                </div>
-              | Some(selectedPull) =>
-                if pullsForRepo->Belt.Array.some(((pullNr, _)) => pullNr == selectedPull) {
-                  let benchmarksForPull = collectBenchmarksForPull(
-                    ~repo=selectedRepo,
-                    ~pull=selectedPull,
-                    benchmarks,
-                  )
-                  <Content
-                    pulls=pullsForRepo
-                    selectedRepo
-                    repos
-                    benchmarks=benchmarksForPull
-                    selectedPull
-                    startDate
-                    endDate
-                    onSelectDateRange
-                    synchronize
-                    onSynchronizeToggle
-                  />
-                } else {
-                  <div> {"This pull request does not exist!"->Rx.string} </div>
-                }
+        | Some(selectedRepo) =>
+          let pulls = collectPullsForRepo(~repo=selectedRepo, benchmarks)
+          switch rest {
+          | list{"pull", pullNumberStr} =>
+            switch Belt.Int.fromString(pullNumberStr) {
+            | None =>
+              <div> {("Pull request must be an integer. Got: " ++ pullNumberStr)->Rx.string} </div>
+            | Some(selectedPull) =>
+              if pulls->Belt.Array.some(((pullNr, _)) => pullNr == selectedPull) {
+                let benchmarksForPull = collectBenchmarksForPull(
+                  ~repo=selectedRepo,
+                  ~pull=selectedPull,
+                  benchmarks,
+                )
+                <Content
+                  pulls
+                  selectedRepo
+                  repos
+                  benchmarks=benchmarksForPull
+                  selectedPull
+                  startDate
+                  endDate
+                  onSelectDateRange
+                  synchronize
+                  onSynchronizeToggle
+                />
+              } else {
+                <div> {"This pull request does not exist!"->Rx.string} </div>
               }
-            | _ =>
-              let benchmarksForMaster = Belt.Array.keep(benchmarksForRepo, (
-                item: GetBenchmarks.t_benchmarks,
-              ) => {
-                Belt.Option.isNone(item.pull_number)
-              })
-              <Content
-                pulls=pullsForRepo
-                selectedRepo
-                repos
-                benchmarks=benchmarksForMaster
-                startDate
-                endDate
-                onSelectDateRange
-                synchronize
-                onSynchronizeToggle
-              />
             }
+          | _ =>
+            let benchmarksForRepo = collectBenchmarksForRepo(~repo=selectedRepo, benchmarks)
+            let benchmarksForMaster = Belt.Array.keep(benchmarksForRepo, (
+              item: GetBenchmarks.t_benchmarks,
+            ) => {
+              Belt.Option.isNone(item.pull_number)
+            })
+            <Content
+              pulls
+              selectedRepo
+              repos
+              benchmarks=benchmarksForMaster
+              startDate
+              endDate
+              onSelectDateRange
+              synchronize
+              onSynchronizeToggle
+            />
           }
         }
       }

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -250,6 +250,7 @@ let make = () => {
             let benchmarksForMaster = Belt.Array.keep(benchmarksForRepo, (
               item: GetBenchmarks.t_benchmarks,
             ) => {
+              // pullNumber is assumed to be None only for master
               Belt.Option.isNone(item.pull_number)
             })
             <Content

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -206,6 +206,7 @@ let make = () => {
     | list{""} =>
       switch Belt.Array.get(repos, 0) {
       | Some(firstRepo) => {
+          // If no repository is selected, this redirects to the first one.
           ReasonReact.Router.replace("#/" ++ firstRepo)
           React.null
         }

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -247,7 +247,7 @@ let make = () => {
                 <div> {"This pull request does not exist!"->Rx.string} </div>
               }
             }
-          | _ =>
+          | list{} =>
             let benchmarksForRepo = collectBenchmarksForRepo(~repo_id=selectedRepoId, benchmarks)
             let benchmarksForMaster = Belt.Array.keep(benchmarksForRepo, (
               item: GetBenchmarks.t_benchmarks,
@@ -266,6 +266,7 @@ let make = () => {
               synchronize
               onSynchronizeToggle
             />
+          | _ => <div> {("Unknown route: " ++ url.hash)->Rx.string} </div>
           }
         }
       }

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -200,7 +200,7 @@ let make = () => {
   | Data(data)
   | PartialData(data, _) =>
     let benchmarks: array<GetBenchmarks.t_benchmarks> = data.benchmarks
-    let repos = collectRepos(data.benchmarks)->Belt.Array.concat(["mirage/second", "mirage/third"])
+    let repos = collectRepos(data.benchmarks)
 
     switch String.split_on_char('/', url.hash) {
     | list{""} =>

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -20,7 +20,7 @@ query ($startDate: timestamp!, $endDate: timestamp!) {
 
 module PullCompare = Belt.Id.MakeComparable({
   type t = (int, option<string>)
-  let cmp = compare
+  let cmp = (a, b) => -compare(a, b)
 })
 
 let collectBenchmarksForRepo = (~repo_id, data: array<GetBenchmarks.t_benchmarks>): array<

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -7,10 +7,10 @@ type testMetrics = {
   metrics: Belt.Map.String.t<float>,
 }
 
-let commitUrl = (repo, commit) => `https://github.com/${repo}/commit/${commit}`
-let goToCommitLink = (repo, commit) => {
+let commitUrl = (repo_id, commit) => `https://github.com/${repo_id}/commit/${commit}`
+let goToCommitLink = (repo_id, commit) => {
   let openUrl: string => unit = %raw(`function (url) { window.open(url, "_blank") }`)
-  openUrl(commitUrl(repo, commit))
+  openUrl(commitUrl(repo_id, commit))
 }
 
 let groupByTestName = (acc, item: testMetrics, idx) => {
@@ -84,7 +84,7 @@ let calcDeltaStr = (a, b) => {
 let renderMetricOverviewRow = (
   ~comparisonMetrics: option<testMetrics>=?,
   ~xTicks,
-  ~repo,
+  ~repo_id,
   metricName,
   data,
 ) => {
@@ -109,7 +109,9 @@ let renderMetricOverviewRow = (
 
     <Table.Row key=metricName>
       <Table.Col> {Rx.text(metricName)} </Table.Col>
-      <Table.Col> <Link target="_blank" href={commitUrl(repo, commit)} text=commit /> </Table.Col>
+      <Table.Col>
+        <Link target="_blank" href={commitUrl(repo_id, commit)} text=commit />
+      </Table.Col>
       <Table.Col> {Rx.text(last_value->Js.Float.toFixedWithPrecision(~digits=2))} </Table.Col>
       <Table.Col sx=[Sx.text.right]> {Rx.text(vsMasterAbs)} </Table.Col>
       <Table.Col sx=[Sx.text.right]> {Rx.text(vsMasterRel)} </Table.Col>
@@ -118,7 +120,14 @@ let renderMetricOverviewRow = (
 }
 
 @react.component
-let make = (~data, ~repo, ~testName, ~comparisonMetrics=?, ~testSelection, ~synchronize=true) => {
+let make = (
+  ~data,
+  ~repo_id,
+  ~testName,
+  ~comparisonMetrics=?,
+  ~testSelection,
+  ~synchronize=true,
+) => {
   let dataByMetrics = data->groupDataByMetric(testSelection)
   let graphRefs = ref(list{})
   let onGraphRender = graph => graphRefs := Belt.List.add(graphRefs.contents, graph)
@@ -151,27 +160,30 @@ let make = (~data, ~repo, ~testName, ~comparisonMetrics=?, ~testSelection, ~sync
       </thead>
       <tbody>
         {dataByMetrics
-        ->Belt.Map.String.mapWithKey(renderMetricOverviewRow(~xTicks, ~repo, ~comparisonMetrics?))
+        ->Belt.Map.String.mapWithKey(
+          renderMetricOverviewRow(~xTicks, ~repo_id, ~comparisonMetrics?),
+        )
         ->Belt.Map.String.valuesToArray
         ->Rx.array}
       </tbody>
     </Table>
   }
 
-  let metric_graphs = dataByMetrics
-  ->Belt.Map.String.mapWithKey((metricName, data) => {
-    <LineGraph
-      onXLabelClick={commit => goToCommitLink(repo, commit)}
-      onRender=onGraphRender
-      key=metricName
-      title=metricName
-      xTicks
-      data={data->Belt.Array.sliceToEnd(-20)}
-      labels=["idx", "value"]
-    />
-  })
-  ->Belt.Map.String.valuesToArray
-  ->Rx.array
+  let metric_graphs =
+    dataByMetrics
+    ->Belt.Map.String.mapWithKey((metricName, data) => {
+      <LineGraph
+        onXLabelClick={commit => goToCommitLink(repo_id, commit)}
+        onRender=onGraphRender
+        key=metricName
+        title=metricName
+        xTicks
+        data={data->Belt.Array.sliceToEnd(-20)}
+        labels=["idx", "value"]
+      />
+    })
+    ->Belt.Map.String.valuesToArray
+    ->Rx.array
 
   <details className={Sx.make([Sx.w.full])} open_=true>
     <summary className={Sx.make([Sx.pointer])}>

--- a/frontend/src/Litepicker.res
+++ b/frontend/src/Litepicker.res
@@ -32,9 +32,8 @@ let make = (~sx as uSx=[], ~startDate=?, ~endDate=?, ~onSelect=?) => {
     )
   }
   let elementRef = React.useRef(Js.Nullable.null)
-  let dates = #dates
 
-  React.useEffect1(() => {
+  React.useEffect0(() => {
     let options = {
       "element": elementRef.current |> Js.Nullable.toOption |> Belt.Option.getExn,
       "startDate": startDate |> Js.Null.fromOption,
@@ -47,7 +46,7 @@ let make = (~sx as uSx=[], ~startDate=?, ~endDate=?, ~onSelect=?) => {
     let _self = init(options)
 
     None
-  }, [dates])
+  })
 
   let sx = Array.append(uSx, containerSx)
   <Row sx alignX=#center alignY=#center>

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -1,8 +1,8 @@
 open! Prelude
 open Components
 
-let linkForPull = ((pull_number, _)) => {
-  "/pull/" ++ Belt.Int.toString(pull_number)
+let linkForPull = (repo, (pull_number, _)) => {
+  "#/" ++ repo ++ "/pull/" ++ Belt.Int.toString(pull_number)
 }
 
 let pullToString = ((pull_number, branch)) =>
@@ -27,7 +27,7 @@ module PullsMenu = {
             selectedPullNumber == pull_number
           )}
           key={string_of_int(i)}
-          href={"#/" ++ repo ++ linkForPull(pull)}
+          href={linkForPull(repo, pull)}
           text={pullToString(pull)}
         />
       })

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -2,7 +2,7 @@ open! Prelude
 open Components
 
 let linkForPull = ((pull_number, _)) => {
-  "/#/pull/" ++ Belt.Int.toString(pull_number)
+  "/pull/" ++ Belt.Int.toString(pull_number)
 }
 
 let pullToString = ((pull_number, branch)) =>
@@ -11,30 +11,52 @@ let pullToString = ((pull_number, branch)) =>
   | None => "#" ++ Belt.Int.toString(pull_number)
   }
 
-let pullsMenu = (~pulls) => {
-  <Column>
-    <Text color=Sx.gray700 weight=#bold uppercase=true size=#md> {Rx.text("Pull Requests")} </Text>
-    {pulls
-    ->Belt.Array.mapWithIndex((i, pull) =>
-      <Link key={string_of_int(i)} href={linkForPull(pull)} text={pullToString(pull)} />
-    )
-    ->Rx.array}
-  </Column>
+module PullsMenu = {
+  @react.component
+  let make = (~pulls, ~repo, ~selectedPull=?) => {
+    Js.log(selectedPull)
+    <Column>
+      <Text color=Sx.gray700 weight=#bold uppercase=true size=#md>
+        {Rx.text("Pull Requests")}
+      </Text>
+      {pulls
+      ->Belt.Array.mapWithIndex((i, pull) => {
+        let (pull_number, _) = pull
+        <Link
+          active={selectedPull->Belt.Option.mapWithDefault(false, selectedPullNumber =>
+            selectedPullNumber == pull_number
+          )}
+          key={string_of_int(i)}
+          href={"#/" ++ repo ++ linkForPull(pull)}
+          text={pullToString(pull)}
+        />
+      })
+      ->Rx.array}
+    </Column>
+  }
 }
 
 @react.component
-let make = (~url: ReasonReact.Router.url, ~pulls, ~onSynchronizeToggle, ~synchronize) => {
-  let repo_name = "mirage/index"
+let make = (
+  ~pulls,
+  ~selectedRepo,
+  ~repos,
+  ~onSelectRepo,
+  ~onSynchronizeToggle,
+  ~synchronize,
+  ~selectedPull=?,
+) => {
   <Column spacing=Sx.xl2 sx=Styles.sidebarSx>
-    <a className={Sx.make([Sx.text.noUnderline, Sx.text.color(Sx.black)])} href="/#">
-      <Row spacing=Sx.lg>
-        <Icon sx=[Sx.unsafe("width", "48px"), Sx.mt.md] svg=Icon.ocaml />
-        <Column spacing=#px(-6)>
-          <Heading level=#h4 sx=[Sx.m.zero] text=repo_name />
-          <Text size=#sm color=Sx.gray800> {Rx.text("Benchmarks")} </Text>
-        </Column>
-      </Row>
-    </a>
-    {pullsMenu(~pulls)}
+    <select
+      name="repos"
+      value={selectedRepo}
+      onChange={e => ReactEvent.Form.target(e)["value"]->onSelectRepo}>
+      {repos
+      ->Belt.Array.mapWithIndex((i, repo) =>
+        <option key={string_of_int(i)} value={repo}> {Rx.string(repo)} </option>
+      )
+      ->Rx.array}
+    </select>
+    <PullsMenu repo=selectedRepo pulls ?selectedPull />
   </Column>
 }

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -14,7 +14,6 @@ let pullToString = ((pull_number, branch)) =>
 module PullsMenu = {
   @react.component
   let make = (~pulls, ~repo, ~selectedPull=?) => {
-    Js.log(selectedPull)
     <Column>
       <Text color=Sx.gray700 weight=#bold uppercase=true size=#md>
         {Rx.text("Pull Requests")}

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -46,16 +46,17 @@ let make = (
   ~selectedPull=?,
 ) => {
   <Column spacing=Sx.xl2 sx=Styles.sidebarSx>
-    <select
+    <Components.Select
       name="repositories"
       value={selectedRepoId}
+      placeholder="Select a repository"
       onChange={e => ReactEvent.Form.target(e)["value"]->onSelectRepoId}>
       {repo_ids
       ->Belt.Array.mapWithIndex((i, repo_id) =>
         <option key={string_of_int(i)} value={repo_id}> {Rx.string(repo_id)} </option>
       )
       ->Rx.array}
-    </select>
+    </Components.Select>
     <PullsMenu repo_id=selectedRepoId pulls ?selectedPull />
   </Column>
 }

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -1,8 +1,8 @@
 open! Prelude
 open Components
 
-let linkForPull = (repo, (pull_number, _)) => {
-  "#/" ++ repo ++ "/pull/" ++ Belt.Int.toString(pull_number)
+let linkForPull = (repo_id, (pull_number, _)) => {
+  "#/" ++ repo_id ++ "/pull/" ++ Belt.Int.toString(pull_number)
 }
 
 let pullToString = ((pull_number, branch)) =>
@@ -13,7 +13,7 @@ let pullToString = ((pull_number, branch)) =>
 
 module PullsMenu = {
   @react.component
-  let make = (~pulls, ~repo, ~selectedPull=?) => {
+  let make = (~pulls, ~repo_id, ~selectedPull=?) => {
     <Column>
       <Text color=Sx.gray700 weight=#bold uppercase=true size=#md>
         {Rx.text("Pull Requests")}
@@ -26,7 +26,7 @@ module PullsMenu = {
             selectedPullNumber == pull_number
           )}
           key={string_of_int(i)}
-          href={linkForPull(repo, pull)}
+          href={linkForPull(repo_id, pull)}
           text={pullToString(pull)}
         />
       })
@@ -38,24 +38,24 @@ module PullsMenu = {
 @react.component
 let make = (
   ~pulls,
-  ~selectedRepo,
-  ~repos,
-  ~onSelectRepo,
+  ~selectedRepoId,
+  ~repo_ids,
+  ~onSelectRepoId,
   ~onSynchronizeToggle,
   ~synchronize,
   ~selectedPull=?,
 ) => {
   <Column spacing=Sx.xl2 sx=Styles.sidebarSx>
     <select
-      name="repos"
-      value={selectedRepo}
-      onChange={e => ReactEvent.Form.target(e)["value"]->onSelectRepo}>
-      {repos
-      ->Belt.Array.mapWithIndex((i, repo) =>
-        <option key={string_of_int(i)} value={repo}> {Rx.string(repo)} </option>
+      name="repositories"
+      value={selectedRepoId}
+      onChange={e => ReactEvent.Form.target(e)["value"]->onSelectRepoId}>
+      {repo_ids
+      ->Belt.Array.mapWithIndex((i, repo_id) =>
+        <option key={string_of_int(i)} value={repo_id}> {Rx.string(repo_id)} </option>
       )
       ->Rx.array}
     </select>
-    <PullsMenu repo=selectedRepo pulls ?selectedPull />
+    <PullsMenu repo_id=selectedRepoId pulls ?selectedPull />
   </Column>
 }

--- a/frontend/src/index.res
+++ b/frontend/src/index.res
@@ -1,6 +1,6 @@
 let fetchOptions = ReasonUrql.Client.FetchOpts(
   Fetch.RequestInit.make(
-    ~headers=Fetch.HeadersInit.make({"X-Hasura-Admin-Secret": "<GRAPHQL_SECRET>"}),
+    ~headers=Fetch.HeadersInit.make({"X-Hasura-Admin-Secret": "zbNoMU69kxiw"}),
     (),
   ),
 )


### PR DESCRIPTION
This PR allows selecting a repository (via a `<select />`) and sync the URL based on the selected repo. I guess the next step would be to filter data based on the selected date ranges and sync that with the URL too. 

https://user-images.githubusercontent.com/5595092/107287923-f41fdc00-6a62-11eb-8360-2a71b777ff06.mov

We currently fetch all the data from the database and filter them out on the frontend. I'm planning to explore if we couldn't make that better by letting some components fetching their own data.