### PR TITLE
get rid of hash in url

### DIFF
--- a/frontend/src/Components.res
+++ b/frontend/src/Components.res
@@ -918,7 +918,7 @@ module Link = {
   }
 
   @react.component
-  let make = (~text=?, ~active=false, ~target=?, ~sx as uSx=[], ~icon=?, ~href=?) => {
+  let make = (~text=?, ~active=false, ~target=?, ~sx as uSx=[], ~icon=?, ~href) => {
     let (text, sx_icon_hover, sx_size) = switch text {
     | Some(text) => (<span> {React.string(text)} </span>, [], sx_medium)
     | None => (React.null, sx_icon_hover, [])
@@ -939,7 +939,24 @@ module Link = {
       },
       uSx,
     })
-    <a className={Sx.make(sx)} ?href ?target> icon_svg text </a>
+    <a
+      className={Sx.make(sx)}
+      href
+      ?target
+      onClick={event =>
+        // https://github.com/MinimaHQ/safe-routing-blog-app-example/blob/master/02-multiple-types/src/Router.re
+        if (
+          !(event->ReactEvent.Mouse.defaultPrevented) &&
+          (event->ReactEvent.Mouse.button == 0 &&
+          (!(event->ReactEvent.Mouse.altKey) &&
+          (!(event->ReactEvent.Mouse.ctrlKey) &&
+          (!(event->ReactEvent.Mouse.metaKey) && !(event->ReactEvent.Mouse.shiftKey)))))
+        ) {
+          event->ReactEvent.Mouse.preventDefault
+          href->ReasonReactRouter.push
+        }}>
+      icon_svg text
+    </a>
   }
 }
 


### PR DESCRIPTION
That's definitely not a big deal but it still feels more "natural" to me to not have this "#" in the URL. I was actually quite surprised to see this hash in the URL at first. I vaguely remember having used this kind of URL when I was working on my first web app. I guess that now all the routing library we use just handle URLs without hash correctly.

The only "benefit" is that we can now use the `url.path` which is already a list. 

Feel free to close if that doesn't sound relevant to you :) 