### PR TITLE
Fix master ordering error

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -27,7 +27,7 @@ query ($repoId: String!, $pullNumber: Int, $isMaster: Boolean!, $startDate: time
     ...BenchmarkMetrics
   }
 
-  comparisonBenchmarks: benchmarks(where: {_and: [{pull_number: {_is_null: true}}, {repo_id: {_eq: $repoId}}, {run_at: {_gte: $startDate}}, {run_at: {_lt: $endDate}}]}, limit: $comparisonLimit) {
+  comparisonBenchmarks: benchmarks(where: {_and: [{pull_number: {_is_null: true}}, {repo_id: {_eq: $repoId}}, {run_at: {_gte: $startDate}}, {run_at: {_lt: $endDate}}]}, limit: $comparisonLimit, order_by: [{run_at: desc}]) {
     ...BenchmarkMetrics
   }
 }
@@ -40,7 +40,7 @@ let makeGetBenchmarksVariables = (
   ~endDate,
 ): GetBenchmarks.t_variables => {
   let isMaster = Belt.Option.isNone(pullNumber)
-  let comparisonLimit = isMaster ? 0 : 10
+  let comparisonLimit = isMaster ? 0 : 50
   {
     repoId: repoId,
     pullNumber: pullNumber,
@@ -112,7 +112,10 @@ module BenchmarkView = {
     | PartialData(data, _) =>
       Js.log(data)
       let benchmarkDataByTestName = data.benchmarks->makeBenchmarkData
-      let comparisonBenchmarkDataByTestName = data.comparisonBenchmarks->makeBenchmarkData
+      let comparisonBenchmarkDataByTestName = {
+        data.comparisonBenchmarks->Belt.Array.reverseInPlace
+        data.comparisonBenchmarks->makeBenchmarkData
+      }
 
       let graphs = {
         benchmarkDataByTestName


### PR DESCRIPTION
Fixes a with master data for comparison. Instead of requesting the last N commits we were requesting the first N commits. I couldn't find a clean solution for this with Hasura. The current approach reverses the obtained commits before using them.

In addition to that, I increased the limit from 10 to 50. This is because 10 is _not_ the number of commits, but the number of datapoints across different test_cases. I'm not sure what's an ideal number for this, but we can always change it later.