### PR TITLE
avoid array mutation

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -112,10 +112,8 @@ module BenchmarkView = {
     | PartialData(data, _) =>
       Js.log(data)
       let benchmarkDataByTestName = data.benchmarks->makeBenchmarkData
-      let comparisonBenchmarkDataByTestName = {
-        data.comparisonBenchmarks->Belt.Array.reverseInPlace
-        data.comparisonBenchmarks->makeBenchmarkData
-      }
+      let comparisonBenchmarkDataByTestName =
+        data.comparisonBenchmarks->Belt.Array.reverse->makeBenchmarkData
 
       let graphs = {
         benchmarkDataByTestName


### PR DESCRIPTION
I'm experiencing some strange behavior when I switch from one PR to another one (graphs change multiple times). The array mutation introduced [here](https://github.com/ocurrent/current-bench/pull/44/files#diff-8f4030cb251d01d332725cad16d13873cbd7fd43197683c0c0a52fac75fe1281R116) seems to be the cause of the issue.

![2021-02-23 19 50 29](https://user-images.githubusercontent.com/5595092/108892949-c9ac5200-7610-11eb-9152-12bb12b3e024.gif)
