### PR TITLE
Improve x labels

### DIFF
--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -109,7 +109,11 @@ let renderMetricOverviewRow = (
 
     <Table.Row key=metricName>
       <Table.Col> {Rx.text(metricName)} </Table.Col>
-      <Table.Col> <Link target="_blank" href={commitUrl(~repoId, commit)} text={commit->DataHelpers.trimCommit} /> </Table.Col>
+      <Table.Col>
+        <Link
+          target="_blank" href={commitUrl(~repoId, commit)} text={commit->DataHelpers.trimCommit}
+        />
+      </Table.Col>
       <Table.Col> {Rx.text(last_value->Js.Float.toFixedWithPrecision(~digits=2))} </Table.Col>
       <Table.Col sx=[Sx.text.right]> {Rx.text(vsMasterAbs)} </Table.Col>
       <Table.Col sx=[Sx.text.right]> {Rx.text(vsMasterRel)} </Table.Col>
@@ -211,7 +215,7 @@ let make = (
         data={timeseries->Belt.Array.sliceToEnd(-20)}
         annotations
         labels=["idx", "value"]
-        onXLabelClick=goToCommitLink(~repoId)
+        onXLabelClick={goToCommitLink(~repoId)}
       />
     })
     ->Belt.Map.String.valuesToArray

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -185,8 +185,11 @@ let make = React.memo((
   // Dygraph does not display the last tick, so a dummy value
   // is added a the end of the data to overcome this.
   // See: https://github.com/danvk/dygraphs/issues/506
-  let lastData = data[Belt.Array.length(data) - 1]
-  let data = data->Belt.Array.concat([[lastData[0] +. 1.0, Obj.magic(Js.Nullable.null)]])
+  let lastRow = data->BeltHelpers.Array.last
+  let data = switch lastRow {
+  | Some(lastRow) => BeltHelpers.Array.push(data, [lastRow[0] +. 1.0, Obj.magic(Js.Nullable.null)])
+  | None => data
+  }
 
   React.useEffect1(() => {
     let options = defaultOptions(

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -181,6 +181,13 @@ let make = React.memo((
 ) => {
   let graphDivRef = React.useRef(Js.Nullable.null)
   let graphRef = React.useRef(None)
+
+  // Dygraph does not display the last tick, so a dummy value
+  // is added a the end of the data to overcome this.
+  // See: https://github.com/danvk/dygraphs/issues/506
+  let lastData = data[Belt.Array.length(data) - 1]
+  let data = data->Belt.Array.concat([[lastData[0] +. 1.0, Obj.magic(Js.Nullable.null)]])
+
   React.useEffect1(() => {
     let options = defaultOptions(
       ~yLabel?,

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -23,7 +23,6 @@ type global
 @module("dygraphs")
 external global: global = "default"
 
-
 @send
 external _synchronize: (global, array<graph>, 'options) => unit = "synchronize"
 
@@ -95,7 +94,6 @@ let defaultOptions = (
         "axisLineWidth": 1.5,
         "axisLabelFormatter": Js.Null.fromOption(xLabelFormatter),
         "ticker": ticker,
-        "axisLabelWidth": 70,
       },
       "y": {
         "drawAxis": true,

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -94,6 +94,7 @@ let defaultOptions = (
         "axisLineWidth": 1.5,
         "axisLabelFormatter": Js.Null.fromOption(xLabelFormatter),
         "ticker": ticker,
+        "axisLabelWidth": 50,
       },
       "y": {
         "drawAxis": true,


### PR DESCRIPTION
Should fix #56 

* [first commit](d7395d9) fixes the latest x label being overlapped. 
* [second commit](https://github.com/ocurrent/current-bench/commit/38b95d844eb371280e8945dae0558b99de8e23d3) fixes the latest commit label that was not shown on the graph. Looks like Dygraph does not display the right-most label. The solution I implemented consist of adding a dummy value to the `data` (see: https://github.com/danvk/dygraphs/issues/506)
* [this commit](3d1079c) is only about formatting


