### PR TITLE
show benchmarks

### DIFF
--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -1,31 +1,96 @@
 open! Prelude
 open Components
 
-let linkForPull = (repoId, (pullNumber, _)) => {
-  AppRouter.RepoPull({repoId: repoId, pullNumber: pullNumber})->AppRouter.path
-}
-
 let pullToString = ((pullNumber, branch)) =>
   switch branch {
   | Some(branch) => "#" ++ Belt.Int.toString(pullNumber) ++ " - " ++ branch
   | None => "#" ++ Belt.Int.toString(pullNumber)
   }
 
-module GetRepoPulls = %graphql(`
+module SidebarMenuData = %graphql(`
 query ($repoId: String!) {
-  pullNumbers: benchmarks(distinct_on: [pull_number], where: {_and: [{repo_id: {_eq: $repoId}}, {pull_number: {_is_null: false}}]}, order_by: [{pull_number: desc}]) {
+  pullsMenuData: benchmarks(distinct_on: [pull_number], where: {_and: [{repo_id: {_eq: $repoId}}, {pull_number: {_is_null: false}}]}, order_by: [{pull_number: desc}]) {
     pull_number
     branch
   }  
+  benchmarksMenuData: benchmarks(distinct_on: [benchmark_name], where: {repo_id: {_eq: $repoId}}, order_by: [{benchmark_name: asc_nulls_first}]) {
+    benchmark_name
+  }
 }
 `)
 
 module PullsMenu = {
   @react.component
-  let make = (~repoId, ~selectedPull=?) => {
+  let make = (
+    ~repoId,
+    ~data: array<SidebarMenuData.t_pullsMenuData>,
+    ~selectedPull=?,
+    ~selectedBenchmarkName=?,
+  ) => {
+    let pullNumbers = data->Belt.Array.keepMap(obj => obj.pull_number)
+
+    pullNumbers
+    ->Belt.Array.mapWithIndex((i, pullNumber) => {
+      <Link
+        sx=[Sx.pb.md]
+        active={selectedPull->Belt.Option.mapWithDefault(false, selectedPullNumber =>
+          selectedPullNumber == pullNumber
+        )}
+        key={string_of_int(i)}
+        href={AppRouter.RepoPull({
+          repoId: repoId,
+          pullNumber: pullNumber,
+          benchmarkName: selectedBenchmarkName,
+        })->AppRouter.path}
+        text={pullToString((pullNumber, None))}
+      />
+    })
+    ->Rx.array(~empty="None"->Rx.string)
+  }
+}
+
+module BenchmarksMenu = {
+  @react.component
+  let make = (
+    ~repoId,
+    ~data: array<SidebarMenuData.t_benchmarksMenuData>,
+    ~selectedPull=?,
+    ~selectedBenchmarkName=?,
+  ) => {
+    data
+    ->Belt.Array.mapWithIndex((i, {benchmark_name: benchmarkName}) => {
+      let benchmarkRoute = switch selectedPull {
+      | None =>
+        AppRouter.Repo({
+          repoId: repoId,
+          benchmarkName: benchmarkName,
+        })
+      | Some(pullNumber) =>
+        AppRouter.RepoPull({
+          repoId: repoId,
+          pullNumber: pullNumber,
+          benchmarkName: benchmarkName,
+        })
+      }
+
+      <Link
+        sx=[Sx.pb.md, Sx.text.capital]
+        active={selectedBenchmarkName == benchmarkName}
+        key={string_of_int(i)}
+        href={benchmarkRoute->AppRouter.path}
+        text={benchmarkName->Belt.Option.getWithDefault("main")}
+      />
+    })
+    ->Rx.array(~empty="None"->Rx.string)
+  }
+}
+
+module SidebarMenu = {
+  @react.component
+  let make = (~repoId, ~selectedPull=?, ~selectedBenchmarkName=?) => {
     let ({ReasonUrql.Hooks.response: response}, _) = {
       ReasonUrql.Hooks.useQuery(
-        ~query=module(GetRepoPulls),
+        ~query=module(SidebarMenuData),
         {
           repoId: repoId,
         },
@@ -38,30 +103,30 @@ module PullsMenu = {
     | Error({networkError: None}) => <div> {"Unknown Error"->Rx.text} </div>
     | Fetching => Rx.text("Loading...")
     | Data(data)
-    | PartialData(data, _) =>
-      let pulls =
-        data.pullNumbers->Belt.Array.map(obj => (obj.pull_number |> Belt.Option.getExn, obj.branch))
-
-      pulls
-      ->Belt.Array.mapWithIndex((i, pull) => {
-        let (pullNumber, _) = pull
-        <Link
-          sx=[Sx.pb.md]
-          active={selectedPull->Belt.Option.mapWithDefault(false, selectedPullNumber =>
-            selectedPullNumber == pullNumber
-          )}
-          key={string_of_int(i)}
-          href={linkForPull(repoId, pull)}
-          text={pullToString(pull)}
-        />
-      })
-      ->Rx.array
+    | PartialData(data, _) => <>
+        <Column>
+          <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Benchmarks" </Text>
+          <BenchmarksMenu
+            repoId data=data.benchmarksMenuData ?selectedPull ?selectedBenchmarkName
+          />
+        </Column>
+        <Column>
+          <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Pull Requests" </Text>
+          <PullsMenu repoId data=data.pullsMenuData ?selectedPull ?selectedBenchmarkName />
+        </Column>
+      </>
     }
   }
 }
 
 @react.component
-let make = (~repoIds, ~selectedRepoId=?, ~onSelectRepoId, ~selectedPull=?) => {
+let make = (
+  ~repoIds,
+  ~selectedRepoId=?,
+  ~onSelectRepoId,
+  ~selectedPull=?,
+  ~selectedBenchmarkName=?,
+) => {
   <Column
     spacing=Sx.xl
     sx=[
@@ -101,12 +166,9 @@ let make = (~repoIds, ~selectedRepoId=?, ~onSelectRepoId, ~selectedPull=?) => {
         ->Rx.array}
       </Select>
     </Column>
-    <Column>
-      <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Pull Requests" </Text>
-      {switch selectedRepoId {
-      | Some(repoId) => <PullsMenu repoId ?selectedPull />
-      | None => Rx.text("None")
-      }}
-    </Column>
+    {switch selectedRepoId {
+    | Some(repoId) => <SidebarMenu repoId ?selectedPull ?selectedBenchmarkName />
+    | None => Rx.null
+    }}
   </Column>
 }

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -33,9 +33,7 @@ module PullsMenu = {
     ->Belt.Array.mapWithIndex((i, pullNumber) => {
       <Link
         sx=[Sx.pb.md]
-        active={selectedPull->Belt.Option.mapWithDefault(false, selectedPullNumber =>
-          selectedPullNumber == pullNumber
-        )}
+        active={selectedPull === Some(pullNumber)}
         key={string_of_int(i)}
         href={AppRouter.RepoPull({
           repoId: repoId,

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -23,11 +23,11 @@ module PullsMenu = {
   @react.component
   let make = (
     ~repoId,
-    ~data: array<SidebarMenuData.t_pullsMenuData>,
+    ~pullsMenuData: array<SidebarMenuData.t_pullsMenuData>,
     ~selectedPull=?,
     ~selectedBenchmarkName=?,
   ) => {
-    let pullNumbers = data->Belt.Array.keepMap(obj => obj.pull_number)
+    let pullNumbers = pullsMenuData->Belt.Array.keepMap(obj => obj.pull_number)
 
     pullNumbers
     ->Belt.Array.mapWithIndex((i, pullNumber) => {
@@ -53,11 +53,11 @@ module BenchmarksMenu = {
   @react.component
   let make = (
     ~repoId,
-    ~data: array<SidebarMenuData.t_benchmarksMenuData>,
+    ~benchmarksMenuData: array<SidebarMenuData.t_benchmarksMenuData>,
     ~selectedPull=?,
     ~selectedBenchmarkName=?,
   ) => {
-    data
+    benchmarksMenuData
     ->Belt.Array.mapWithIndex((i, {benchmark_name: benchmarkName}) => {
       let benchmarkRoute = switch selectedPull {
       | None =>
@@ -102,17 +102,15 @@ module SidebarMenu = {
     | Error({networkError: Some(_)}) => <div> {"Network Error"->Rx.text} </div>
     | Error({networkError: None}) => <div> {"Unknown Error"->Rx.text} </div>
     | Fetching => Rx.text("Loading...")
-    | Data(data)
-    | PartialData(data, _) => <>
+    | Data({benchmarksMenuData, pullsMenuData})
+    | PartialData({benchmarksMenuData, pullsMenuData}, _) => <>
         <Column>
           <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Benchmarks" </Text>
-          <BenchmarksMenu
-            repoId data=data.benchmarksMenuData ?selectedPull ?selectedBenchmarkName
-          />
+          <BenchmarksMenu repoId benchmarksMenuData ?selectedPull ?selectedBenchmarkName />
         </Column>
         <Column>
           <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Pull Requests" </Text>
-          <PullsMenu repoId data=data.pullsMenuData ?selectedPull ?selectedBenchmarkName />
+          <PullsMenu repoId pullsMenuData ?selectedPull ?selectedBenchmarkName />
         </Column>
       </>
     }


### PR DESCRIPTION
This PR adds a new menu to the sidebar that displays the benchmarks available for the selected repository. Graph data are then filtered out based on the selected benchmark.

<img width="224" alt="Screenshot 2021-03-20 at 08 54 05" src="https://user-images.githubusercontent.com/5595092/111863159-26720280-895a-11eb-8ec6-a1f2d6e2ad55.png">


Note that:
* `NULL` benchmarks are reported as `Main`
* All benchmarks for the currently selected repository are shown, i.e they're not filtered depending on the selected branch/PR. Is that something we want to support?
* For now, the benchmarks menu is always shown, even if the repository contains only one benchmark. I propose to address this point in a follow-up PR.