### PR TITLE
remove bottom scrollbar from graph

### DIFF
--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -170,7 +170,6 @@ let graphSx = [
 let containerSx = [
   Sx.minW.xl5,
   Sx.unsafe("width", "432px"),
-  Sx.overflow.scroll,
   Sx.relative,
   Sx.mb.xl2,
   Sx.mr.xl2,


### PR DESCRIPTION
This should remove the bottom scrollbar we currently see on the graph.

## Before

<img width="1496" alt="Screenshot 2021-03-20 at 09 30 44" src="https://user-images.githubusercontent.com/5595092/111864065-2a545380-895f-11eb-8889-c7f83ace557f.png">

## After

<img width="1496" alt="Screenshot 2021-03-20 at 09 30 57" src="https://user-images.githubusercontent.com/5595092/111864068-2e807100-895f-11eb-8309-65bfa3c5d69e.png">
