### PR TITLE
Show make bench logs in current UI

### DIFF
--- a/pipeline/lib/current_util.ml
+++ b/pipeline/lib/current_util.ml
@@ -24,8 +24,6 @@ module Docker_util = struct
         run_args : string list;
       }
 
-      let pp_args = Fmt.(list ~sep:sp (quote string))
-
       let cmd { image; args; docker_context; run_args } =
         Cmd.docker ~docker_context
         @@ [ "run" ]

--- a/pipeline/lib/current_util.ml
+++ b/pipeline/lib/current_util.ml
@@ -3,3 +3,88 @@ open Current.Syntax
 let get_job_id x =
   let+ md = Current.Analysis.metadata x in
   match md with Some { Current.Metadata.job_id; _ } -> job_id | None -> None
+
+module Docker_util = struct
+  module Docker = Current_docker.Default
+  module Image = Current_docker.Raw.Image
+  module Cmd = Current_docker.Raw.Cmd
+
+  module Pread_log_builder = struct
+    open Lwt.Infix
+
+    type t = { pool : unit Current.Pool.t option }
+
+    let id = "docker-pread"
+
+    module Key = struct
+      type t = {
+        image : Image.t;
+        args : string list;
+        docker_context : string option;
+        run_args : string list;
+      }
+
+      let pp_args = Fmt.(list ~sep:sp (quote string))
+
+      let cmd { image; args; docker_context; run_args } =
+        Cmd.docker ~docker_context
+        @@ [ "run" ]
+        @ run_args
+        @ [ "--rm"; "-i"; Image.hash image ]
+        @ args
+
+      let pp f t = Cmd.pp f (cmd t)
+
+      let digest { image; args; docker_context; run_args } =
+        Yojson.Safe.to_string
+        @@ `Assoc
+             [
+               ("image", `String (Image.hash image));
+               ("args", `List (List.map (fun arg -> `String arg) args));
+               ( "docker_context",
+                 docker_context
+                 |> Option.map (fun x -> `String x)
+                 |> Option.value ~default:`Null );
+               ("run_args", `List (List.map (fun arg -> `String arg) run_args));
+             ]
+    end
+
+    module Value = Current.String
+
+    let build { pool } job key =
+      Current.Job.start job ?pool ~level:Current.Level.Average >>= fun () ->
+      Current.Process.check_output ~cancellable:true ~job (Key.cmd key)
+      >>= fun output_result ->
+      match output_result with
+      | Ok output ->
+          Current.Job.log job "Output:\n%s" output;
+          Lwt.return output_result
+      | Error (`Msg msg) ->
+          Current.Job.log job "Error: %s" msg;
+          Lwt.return output_result
+
+    let pp = Key.pp
+
+    let auto_cancel = true
+  end
+
+  module Pread_log = Current_cache.Make (Pread_log_builder)
+
+  module Raw = struct
+    let pread_log ~docker_context ?pool ?(run_args = []) image ~args =
+      let image =
+        Current_docker.Default.Image.hash image
+        |> Current_docker.Raw.Image.of_hash
+      in
+      Pread_log.get { Pread_log_builder.pool }
+        { Pread_log_builder.Key.image; args; docker_context; run_args }
+  end
+
+  let pp_sp_label = Fmt.(option (sp ++ string))
+
+  let pread_log ?label ?pool ?run_args image ~args =
+    Current.component "pread_log%a" pp_sp_label label
+    |> let> image = image in
+       Raw.pread_log ~docker_context:Docker.docker_context ?pool ?run_args image
+         ~args
+end

--- a/pipeline/lib/current_util.mli
+++ b/pipeline/lib/current_util.mli
@@ -1,0 +1,13 @@
+val get_job_id : 'a Current.t -> string option Current.t
+
+module Docker_util : sig
+  val pread_log :
+    ?label:string ->
+    ?pool:unit Current.Pool.t ->
+    ?run_args:string list ->
+    Current_docker.Default.Image.t Current.t ->
+    args:string list ->
+    string Current.t
+  (** Similar to {!val:Current_docker.Default.pred} but includes the output in
+      the job's logs. *)
+end

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -2,6 +2,7 @@ open Current.Syntax
 module Git = Current_git
 module Github = Current_github
 module Docker = Current_docker.Default
+module Docker_util = Current_util.Docker_util
 module Slack = Current_slack
 module Logging = Logging
 module Benchmark = Models.Benchmark
@@ -84,7 +85,11 @@ let pipeline ~slack_path ~conninfo ?branch ?pull_number ~dockerfile ~tmpfs
     in
     let run_at = Ptime_clock.now () in
     let current_output =
-      Docker.pread ~run_args current_image ~args:["/usr/bin/setarch"; "x86_64"; "--addr-no-randomize"; "make"; "bench" ]
+      Docker_util.pread_log ~run_args current_image
+        ~args:
+          [
+            "/usr/bin/setarch"; "x86_64"; "--addr-no-randomize"; "make"; "bench";
+          ]
     in
     let+ commit =
       match head with


### PR DESCRIPTION
This implements a custom docker run and read mechanism that is similar to ocurrent's `Docker.pread`, but logs the output in addition to returning it.

Based on: https://github.com/ocurrent/ocurrent/blob/master/plugins/docker/pread.ml


Here's an example output from a benchmark execution with this change:

```
2021-03-23 15:32.41: New job: "docker" "run" "--security-opt"
                     "seccomp=./aslr_seccomp.json" "--tmpfs"
                     "/dev/shm:rw,noexec,nosuid,size=4g" "--cpuset-cpus" 
                     "1" "--rm" "-i"
                     "sha256:3722427047f8eaf4230c9e9465ec554c04e5fca236f03621f11f8ba1c4122bd9"
                     "make" "bench"
2021-03-23 15:32.41: Exec: "docker" "run" "--security-opt" "seccomp=./aslr_seccomp.json" 
                           "--tmpfs" "/dev/shm:rw,noexec,nosuid,size=4g" 
                           "--cpuset-cpus" "1" "--rm" "-i" "sha256:3722427047f8eaf4230c9e9465ec554c04e5fca236f03621f11f8ba1c4122bd9" 
                           "make" "bench"
2021-03-23 15:32.44: Output:
{
  "config": {  },
  "results": [
    {
      "name": "bench_1_test_1",
      "metrics": {
        "time": 4.02,
        "ops_per_sec": 690.0,
        "mbs_per_sec": 199.0
      }
    },
    {
      "name": "bench_1_test_2",
      "metrics": {
        "time": 10.04,
        "ops_per_sec": 1455.0,
        "mbs_per_sec": 17.0
      }
    }
  ]
}
{
  "config": {  },
  "results": [
    {
      "name": "bench_2_test_1",
      "metrics": {
        "time": 0.01,
        "ops_per_sec": 50.0,
        "mbs_per_sec": 3.0
      }
    },
    {
      "name": "bench_2_test_2",
      "metrics": {
        "time": 0.07,
        "ops_per_sec": 877.0,
        "mbs_per_sec": 23.0
      }
    }
  ]
}

2021-03-23 15:32.44: Job succeeded
``