### PR TITLE
prevent legend from being hidden by the PR icon

### DIFF
--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -128,12 +128,11 @@ let defaultOptions = (
   }
 }
 
-Sx.global(".dygraph-legend", [Sx.absolute])
+Sx.global(".dygraph-legend", [Sx.absolute, Sx.z.high])
 Sx.global(
   ".dygraph-legend-formatter",
   [
     Sx.text.sm,
-    Sx.z.high,
     Sx.bg.color(Sx.white),
     Sx.rounded.sm,
     Sx.py.md,


### PR DESCRIPTION
## Before
<img width="410" alt="Screenshot 2021-03-25 at 07 41 02" src="https://user-images.githubusercontent.com/5595092/112430614-ad4e2300-8d3e-11eb-905e-dd61d3879783.png">

## After

<img width="410" alt="Screenshot 2021-03-25 at 07 41 44" src="https://user-images.githubusercontent.com/5595092/112430629-b2ab6d80-8d3e-11eb-90d7-2b6ad963c74b.png">
