### PR TITLE
Responsive graphs

### DIFF
--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -235,7 +235,10 @@ let make = (
         delta == 0.0 ? "Same as master" : deltaToString(delta) ++ " vs master"
       )
 
-      <div key=metricName>
+      <div
+        key=metricName
+        // one: [Css.flex3(~grow=1.0, ~shrink=1.0, ~basis=#percent(0.0))],
+        className={Sx.make([Sx.unsafe("minWidth", "400px"), Sx.unsafe("flex", "1")])}>
         {Topbar.anchor(~id="line-graph-" ++ testName ++ "-" ++ metricName)}
         <LineGraph
           onXLabelClick={goToCommitLink(~repoId)}
@@ -267,6 +270,6 @@ let make = (
       <Text sx=[Sx.w.auto, Sx.text.md, Sx.text.bold, Sx.text.color(Sx.gray900)]> testName </Text>
     </summary>
     {Belt.Map.String.isEmpty(comparison) ? Rx.null : metric_table}
-    <Flex wrap=true> metric_graphs </Flex>
+    <Flex wrap=true sx={[Sx.unsafe("gap", "24px")]}> metric_graphs </Flex>
   </details>
 }

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -235,10 +235,7 @@ let make = (
         delta == 0.0 ? "Same as master" : deltaToString(delta) ++ " vs master"
       )
 
-      <div
-        key=metricName
-        // one: [Css.flex3(~grow=1.0, ~shrink=1.0, ~basis=#percent(0.0))],
-        className={Sx.make([Sx.unsafe("minWidth", "400px"), Sx.unsafe("flex", "1")])}>
+      <div key=metricName>
         {Topbar.anchor(~id="line-graph-" ++ testName ++ "-" ++ metricName)}
         <LineGraph
           onXLabelClick={goToCommitLink(~repoId)}
@@ -270,6 +267,13 @@ let make = (
       <Text sx=[Sx.w.auto, Sx.text.md, Sx.text.bold, Sx.text.color(Sx.gray900)]> testName </Text>
     </summary>
     {Belt.Map.String.isEmpty(comparison) ? Rx.null : metric_table}
-    <Flex wrap=true sx={[Sx.unsafe("gap", "24px")]}> metric_graphs </Flex>
+    <div
+      className={Sx.make([
+        Sx.unsafe("display", "grid"),
+        Sx.unsafe("gap", "32px"), // xl2
+        Sx.unsafe("gridTemplateColumns", "repeat(auto-fit, minmax(400px, 1fr))"),
+      ])}>
+      metric_graphs
+    </div>
   </details>
 }

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -161,23 +161,9 @@ Sx.global(".dygraph-axis-label-y", [Sx.pr.sm])
 
 Sx.global(".dygraph-axis-label", [Sx.text.xs, Sx.z.high, Sx.overflow.hidden, Sx.opacity75])
 
-let graphSx = [
-  Sx.unsafe("width", "400px"),
-  Sx.unsafe("height", "190px"),
-  Sx.unsafe("marginBottom", "40px"),
-]
+let graphSx = [Sx.unsafe("height", "190px"), Sx.unsafe("marginBottom", "40px")]
 
-let containerSx = [
-  Sx.minW.xl5,
-  Sx.unsafe("width", "432px"),
-  Sx.relative,
-  Sx.mb.xl2,
-  Sx.mr.xl2,
-  Sx.border.xs,
-  Sx.border.color(Sx.gray300),
-  Sx.rounded.md,
-  Sx.p.xl,
-]
+let containerSx = [Sx.w.full, Sx.border.xs, Sx.border.color(Sx.gray300), Sx.rounded.md, Sx.p.xl]
 
 open Components
 
@@ -313,8 +299,8 @@ let make = React.memo((
 
   let sx = Array.append(uSx, containerSx)
 
-  <Column sx spacing=Sx.xl>
-    <Row spacing=#between alignY=#top> {left} {right} </Row>
+  <div className={Sx.make(sx)}>
+    <Row spacing=#between alignY=#top sx={[Sx.mb.xl]}> {left} {right} </Row>
     <div className={Sx.make(graphSx)} ref={ReactDOMRe.Ref.domRef(graphDivRef)} />
-  </Column>
+  </div>
 })


### PR DESCRIPTION
Current implementation uses a fixed graph size and tries to fill the current row with as many graphs as possible. When there's not enough space on the current row, we go to the next one. Problem is that we can end up with some space left not being used:

<img width="1706" alt="Screenshot 2021-03-25 at 07 52 34" src="https://user-images.githubusercontent.com/5595092/112431652-14200c00-8d40-11eb-9778-430139023f11.png">

This PR makes the graphs always taking up the entire row so that we avoid this "unused space". The [first commit](https://github.com/ocurrent/current-bench/commit/5d59ec090e3389470daedce606f876cb057d5b72) uses flexbox. I didn't find this solution ideal because the last row will always take the full width, meaning that graphs on this last row can have different sizes (if the number of graphs on this last row is different than the other rows)

<img width="964" alt="Screenshot 2021-03-25 at 07 15 51" src="https://user-images.githubusercontent.com/5595092/112432063-9e687000-8d40-11eb-8c48-cda3c00624a4.png">

[Second commit](https://github.com/ocurrent/current-bench/commit/2c7d96fbb67dd9e10bd3c986aa7a2a29116aa03c) uses CSS grid, that makes every graph have the same size, even for the last row:

<img width="1918" alt="Screenshot 2021-03-25 at 08 14 35" src="https://user-images.githubusercontent.com/5595092/112433201-33b83400-8d42-11eb-898f-97e725547656.png">


A couple of other screenshots taken at different screen resolutions:

<img width="1787" alt="Screenshot 2021-03-25 at 08 11 29" src="https://user-images.githubusercontent.com/5595092/112432850-bb517300-8d41-11eb-92bd-b1ac39524bfd.png">
<img width="1832" alt="Screenshot 2021-03-25 at 08 10 20" src="https://user-images.githubusercontent.com/5595092/112432860-c1475400-8d41-11eb-8dd5-dd0a6313fcb9.png">
<img width="1446" alt="Screenshot 2021-03-25 at 08 10 38" src="https://user-images.githubusercontent.com/5595092/112432864-c4424480-8d41-11eb-9a87-02a55fd47ff8.png">
<img width="1026" alt="Screenshot 2021-03-25 at 08 10 54" src="https://user-images.githubusercontent.com/5595092/112432870-c6a49e80-8d41-11eb-8bca-474763ae0e68.png">

