### PR TITLE
Use error bars in dygraphs.

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -69,7 +69,7 @@ summary::-webkit-details-marker {
   /* font-size: 14px; */
   z-index: 10;
   line-height: normal;
-  overflow: hidden;
+  overflow: visible;
   color: black;  /* replaces old axisLabelColor option */
 }
 

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -226,7 +226,7 @@ module RepoView = {
               <Welcome />
             </Column>
           </>
-        | Some(repoId) when !(repoIds->BeltHelpers.Array.contains(repoId)) =>
+        | Some(repoId) if !(repoIds->BeltHelpers.Array.contains(repoId)) =>
           <ErrorView msg={"No such repository: " ++ repoId} />
         | Some(repoId) =>
           let breadcrumbs =

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -54,19 +54,6 @@ let makeGetBenchmarksVariables = (
   }
 }
 
-let getTestMetrics = (item: BenchmarkMetrics.t): BenchmarkTest.testMetrics => {
-  {
-    BenchmarkTest.name: item.test_name,
-    metrics: item.metrics
-    ->Belt.Option.getExn
-    ->Js.Json.decodeObject
-    ->Belt.Option.getExn
-    ->jsDictToMap
-    ->Belt.Map.String.map(v => BenchmarkTest.decodeMetricValue(v)),
-    commit: item.commit,
-  }
-}
-
 module Benchmark = {
   let decodeRunAt = runAt => runAt->Js.Json.decodeString->Belt.Option.map(Js.Date.fromString)
 
@@ -82,7 +69,7 @@ module Benchmark = {
     benchmarks->Belt.Array.reduce(BenchmarkData.empty, (acc, item) => {
       item.metrics
       ->decodeMetrics
-      ->Belt.Map.String.reduce(acc, (acc, metricName, value) => {
+      ->Belt.Map.String.reduce(acc, (acc, metricName, value: LineGraph.DataRow.value) => {
         BenchmarkData.add(
           acc,
           ~testName=item.test_name,

--- a/frontend/src/BenchmarkData.res
+++ b/frontend/src/BenchmarkData.res
@@ -1,19 +1,26 @@
 open Belt
 
-type timeseries = array<array<float>>
+type timeseries = array<LineGraph.DataRow.t>
 type byMetricName = Map.String.t<(timeseries, array<{"commit": string, "runAt": Js.Date.t}>)>
 type byTestName = Map.String.t<byMetricName>
 type t = byTestName
 
 let empty: t = Map.String.empty
 
-let add = (byTestName: t, ~testName, ~metricName, ~runAt: Js.Date.t, ~commit, ~value: float) => {
+let add = (
+  byTestName: t,
+  ~testName,
+  ~metricName,
+  ~runAt: Js.Date.t,
+  ~commit,
+  ~value: LineGraph.DataRow.value,
+) => {
   // Unwrap
   let byMetricName = Map.String.getWithDefault(byTestName, testName, Map.String.empty)
   let (timeseries, metadata) = Map.String.getWithDefault(byMetricName, metricName, ([], []))
 
   // Update
-  let row = [(Obj.magic(runAt): float), value]
+  let row = LineGraph.DataRow.with_date(runAt, value)
   let timeseries = BeltHelpers.Array.push(timeseries, row)
   let metadata = BeltHelpers.Array.push(metadata, {"commit": commit, "runAt": runAt})
 

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -23,9 +23,7 @@ let groupByTestName = (acc, item: testMetrics, idx) => {
 let decodeMetricValue = (json): LineGraph.DataRow.value => {
   switch Js.Json.classify(json) {
   | JSONNumber(n) => LineGraph.DataRow.single(n)
-  | JSONArray([]) =>
-    Js.log("Empty metrics value array.")
-    LineGraph.DataRow.single(nan)
+  | JSONArray([]) => LineGraph.DataRow.single(nan)
   | JSONArray(xs) =>
     let xs = xs->Belt.Array.map(x => x->Js.Json.decodeNumber->Belt.Option.getExn)
     LineGraph.DataRow.many(xs)

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -4,7 +4,7 @@ open Components
 type testMetrics = {
   name: string,
   commit: string,
-  metrics: Belt.Map.String.t<float>,
+  metrics: Belt.Map.String.t<LineGraph.DataRow.value>,
 }
 
 @module("../icons/branch.svg") external branchIcon: string = "default"
@@ -20,49 +20,19 @@ let groupByTestName = (acc, item: testMetrics, idx) => {
   Belt.Map.String.update(acc, item.name, go)
 }
 
-let decodeMetricValue = json => {
+let decodeMetricValue = (json): LineGraph.DataRow.value => {
   switch Js.Json.classify(json) {
-  | JSONNumber(n) => n
-  | JSONArray([]) => 0.0
-  | JSONArray(ns) =>
-    Belt.Array.get(ns, 0)->Belt.Option.getExn->Js.Json.decodeNumber->Belt.Option.getExn
+  | JSONNumber(n) => LineGraph.DataRow.single(n)
+  | JSONArray([]) =>
+    Js.log("Empty metrics value array.")
+    LineGraph.DataRow.single(nan)
+  | JSONArray(xs) =>
+    let xs = xs->Belt.Array.map(x => x->Js.Json.decodeNumber->Belt.Option.getExn)
+    LineGraph.DataRow.many(xs)
   | _ => invalid_arg("Invalid metric value: " ++ Js.Json.stringify(json))
   }
-}
-
-let collectMetricsByKey = (
-  ~metricName,
-  items: array<testMetrics>,
-  selection: Belt.Set.Int.t,
-): array<array<float>> => {
-  let data = Belt.Array.makeUninitializedUnsafe(Belt.Set.Int.size(selection))
-  Belt.Set.Int.reduce(selection, 0, (i, idx) => {
-    let item: testMetrics = Belt.Array.getExn(items, idx)
-    let metricWithIndex = [idx->float_of_int, item.metrics->Belt.Map.String.getExn(metricName)]
-    Belt.Array.setExn(data, i, metricWithIndex)
-    i + 1
-  })->ignore
-  data
-}
-
-let groupDataByMetric = (items: array<testMetrics>, selection: Belt.Set.Int.t): Belt.Map.String.t<
-  array<array<float>>,
-> => {
-  open Belt
-
-  let addMetricValue = (selectionIdx, acc, metricName, metricValue) => {
-    let x = selectionIdx->float_of_int
-    let y = metricValue
-    let row = [x, y]
-    BeltHelpers.MapString.addToArray(acc, metricName, row)
-  }
-
-  let groupByMetric = (acc, selectionIdx) => {
-    let testMetrics = Array.getExn(items, selectionIdx)
-    testMetrics.metrics->Map.String.reduce(acc, addMetricValue(selectionIdx))
-  }
-
-  selection->Set.Int.reduce(Map.String.empty, groupByMetric)
+  // ->ignore
+  // LineGraph.DataRow.many([Random.float(10.0), 5. +. Random.float(10.0), 10. +. Random.float(10.0)])
 }
 
 let calcDelta = (a, b) => {
@@ -84,7 +54,7 @@ let deltaToString = n =>
 
 let renderMetricOverviewRow = (
   ~repoId,
-  ~comparison as (comparisonTimeseries, _comparisonMetadata)=([], []),
+  ~comparison as (comparisonTimeseries: array<LineGraph.DataRow.t>, _comparisonMetadata)=([], []),
   ~testName,
   ~metricName,
   (timeseries, metadata),
@@ -92,10 +62,10 @@ let renderMetricOverviewRow = (
   if Belt.Array.length(timeseries) == 0 {
     React.null
   } else {
-    let last_value = BeltHelpers.Array.lastExn(timeseries)[1]
+    let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toFloat
     let (vsMasterAbs, vsMasterRel) = switch BeltHelpers.Array.last(comparisonTimeseries) {
     | Some(lastComparisionRow) =>
-      let lastComparisonY = lastComparisionRow[1]
+      let lastComparisonY = lastComparisionRow->LineGraph.DataRow.toFloat
       (
         Js.Float.toPrecisionWithPrecision(~digits=6)(lastComparisonY),
         calcDelta(last_value, lastComparisonY)->deltaToString,
@@ -123,11 +93,11 @@ let getMetricDelta = (
   if Belt.Array.length(timeseries) == 0 {
     None
   } else {
-    let last_value = BeltHelpers.Array.lastExn(timeseries)[1]
+    let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toFloat
 
     switch BeltHelpers.Array.last(comparisonTimeseries) {
     | Some(lastComparisionRow) =>
-      let lastComparisonY = lastComparisionRow[1]
+      let lastComparisonY = lastComparisionRow->LineGraph.DataRow.toFloat
       Some(calcDelta(last_value, lastComparisonY))
     | _ => None
     }
@@ -140,7 +110,7 @@ let make = (
   ~pullNumber,
   ~testName,
   ~comparison=Belt.Map.String.empty,
-  ~dataByMetricName,
+  ~dataByMetricName: Belt.Map.String.t<(array<LineGraph.DataRow.t>, 'a)>,
 ) => {
   let metric_table = {
     <Table sx=[Sx.mb.xl2]>
@@ -182,12 +152,15 @@ let make = (
         ([], []),
       )
 
-      let timeseries = Belt.Array.concat(comparisonTimeseries, timeseries)
+      let timeseries: array<LineGraph.DataRow.t> = Belt.Array.concat(
+        comparisonTimeseries,
+        timeseries,
+      )
       let metadata = Belt.Array.concat(comparisonMetadata, metadata)
 
       let xTicks = Belt.Array.reduceWithIndex(timeseries, Belt.Map.Int.empty, (acc, row, index) => {
         // Use indexed instead of dates. This allows us to map to commits.
-        Belt.Array.set(row, 0, float_of_int(index))->ignore
+        LineGraph.DataRow.set_index(index, row)
         let tick = switch Belt.Array.get(metadata, index) {
         | Some(xMetadata) =>
           let xValue = xMetadata["commit"]


### PR DESCRIPTION
WIP implementation of error bars for metrics with multiple values. The graph shows the mean; the lower bound is the minimum, the upper bound is the maximum.

See this example in dygraphs: https://dygraphs.com/gallery/#g/temperature-sf-ny


This is how it looks in our dashboard:

<img width="1416" alt="Screenshot 2021-04-27 at 17 18 36" src="https://user-images.githubusercontent.com/308413/116278217-344b4c80-a77e-11eb-94b0-27ec3611b7be.png">
