### PR TITLE
Increase precision.

### DIFF
--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -83,9 +83,9 @@ let calcDelta = (a, b) => {
 
 let deltaToString = n =>
   if n > 0.0 {
-    "+" ++ n->Js.Float.toFixedWithPrecision(~digits=2) ++ "%"
+    "+" ++ n->Js.Float.toPrecisionWithPrecision(~digits=6) ++ "%"
   } else {
-    n->Js.Float.toFixedWithPrecision(~digits=2) ++ "%"
+    n->Js.Float.toPrecisionWithPrecision(~digits=6) ++ "%"
   }
 
 let renderMetricOverviewRow = (
@@ -103,7 +103,7 @@ let renderMetricOverviewRow = (
     | Some(lastComparisionRow) =>
       let lastComparisonY = lastComparisionRow[1]
       (
-        Js.Float.toFixedWithPrecision(~digits=2)(lastComparisonY),
+        Js.Float.toPrecisionWithPrecision(~digits=6)(lastComparisonY),
         calcDelta(last_value, lastComparisonY)->deltaToString,
       )
     | _ => ("NA", "NA")
@@ -114,7 +114,7 @@ let renderMetricOverviewRow = (
         <a href={"#line-graph-" ++ testName ++ "-" ++ metricName}> {Rx.text(metricName)} </a>
       </Table.Col>
       <Table.Col sx=[Sx.text.right]>
-        {Rx.text(last_value->Js.Float.toFixedWithPrecision(~digits=2))}
+        {Rx.text(last_value->Js.Float.toPrecisionWithPrecision(~digits=6))}
       </Table.Col>
       <Table.Col sx=[Sx.text.right]> {Rx.text(vsMasterAbs)} </Table.Col>
       <Table.Col sx=[Sx.text.right]> {Rx.text(vsMasterRel)} </Table.Col>

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -107,7 +107,7 @@ let defaultOptions = (
         "gridLinePattern": [5, 5],
         "axisLineColor": "gainsboro",
         "axisLineWidth": 1.5,
-        "axisLabelWidth": 50,
+        "axisLabelWidth": 55,
       },
     },
     "rollPeriod": 1,
@@ -122,6 +122,7 @@ let defaultOptions = (
     "pointClickCallback": Js.Null.fromOption(onClick),
     "colors": ["#0F6FDE"],
     "animatedZooms": true,
+    "digitsAfterDecimal": 6,
     "hideOverlayOnMouseOut": true,
     "labels": Js.Null.fromOption(labels),
     "ylabel": Js.Null.fromOption(yLabel),
@@ -290,7 +291,7 @@ let make = React.memo((
     <Row alignX=#right spacing=Sx.md sx=[Sx.w.auto]>
       <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray900)]>
         {lastValue->Belt.Option.mapWithDefault("", value =>
-          Js.Float.toFixedWithPrecision(~digits=2, value)
+          Js.Float.toPrecisionWithPrecision(~digits=4, value)
         )}
       </Text>
       <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray500)]> {""} </Text> // TODO: unit needs to be added to the metrics


### PR DESCRIPTION
Before:
<img width="432" alt="Screenshot 2021-03-30 at 20 29 02" src="https://user-images.githubusercontent.com/308413/113045292-92443e80-9196-11eb-88ed-0dbb73d83991.png">

After:
<img width="432" alt="Screenshot 2021-03-30 at 20 28 41" src="https://user-images.githubusercontent.com/308413/113045264-85274f80-9196-11eb-9527-a3a1bf73c7d2.png">

Also applies to tables.