### PR TITLE
update to `@urql/rescript` and `@rescript/react`

### DIFF
--- a/frontend/bsconfig.json
+++ b/frontend/bsconfig.json
@@ -18,15 +18,14 @@
   "suffix": ".bs.js",
   "namespace": true,
   "bs-dependencies": [
-    "reason-react",
+    "@rescript/react",
     "bs-css",
     "bs-css-emotion",
     "@reasonml-community/graphql-ppx",
-    "reason-urql",
+    "@urql/rescript",
     "wonka",
     "bs-fetch",
     "@glennsl/bs-json"
   ],
-  "ppx-flags": ["@reasonml-community/graphql-ppx/ppx"],
-  "refmt": 3
+  "ppx-flags": ["@reasonml-community/graphql-ppx/ppx"]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,24 +8,24 @@
     "clean": "bsb -clean-world"
   },
   "devDependencies": {
-    "@reasonml-community/graphql-ppx": "^1.0.2",
+    "@reasonml-community/graphql-ppx": "^1.2.0",
     "@vitejs/plugin-react-refresh": "^1.3.1",
-    "bs-platform": "^8.4.2",
+    "bs-platform": "^9.0.2",
     "gentype": "^3.41.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "reason-react": "^0.9.1",
-    "vite": "^2.0.4"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "vite": "^2.1.4"
   },
   "dependencies": {
     "@glennsl/bs-json": "^5.0.2",
-    "bs-css-emotion": "^2.4.0",
+    "@rescript/react": "^0.10.1",
+    "@urql/rescript": "^4.0.0",
+    "bs-css-emotion": "^2.5.1",
     "bs-fetch": "^0.6.2",
     "dygraphs": "^2.1.0",
-    "graphql": "^15.4.0",
+    "graphql": "^15.5.0",
     "litepicker": "^1.5.7",
-    "reason-urql": "^3.4.0",
-    "urql": "^1.11.6"
+    "urql": "^2.0.1"
   },
   "resolutions": {
     "wonka": "5.0.0-rc.1"

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -130,10 +130,10 @@ module Benchmark = {
 module BenchmarkView = {
   @react.component
   let make = (~repoId, ~pullNumber=?, ~benchmarkName=?, ~startDate, ~endDate) => {
-    let ({ReasonUrql.Hooks.response: response}, _) = {
+    let ({ReScriptUrql.Hooks.response: response}, _) = {
       let startDate = Js.Date.toISOString(startDate)->Js.Json.string
       let endDate = Js.Date.toISOString(endDate)->Js.Json.string
-      ReasonUrql.Hooks.useQuery(
+      ReScriptUrql.Hooks.useQuery(
         ~query=module(GetBenchmarks),
         makeGetBenchmarksVariables(~repoId, ~pullNumber?, ~benchmarkName?, ~startDate, ~endDate),
       )
@@ -197,8 +197,8 @@ module ErrorView = {
 module RepoView = {
   @react.component
   let make = (~repoId=?, ~pullNumber=?, ~benchmarkName=?) => {
-    let ({ReasonUrql.Hooks.response: response}, _) = {
-      ReasonUrql.Hooks.useQuery(~query=module(GetAllRepos), ())
+    let ({ReScriptUrql.Hooks.response: response}, _) = {
+      ReScriptUrql.Hooks.useQuery(~query=module(GetAllRepos), ())
     }
 
     let ((startDate, endDate), setDateRange) = React.useState(getDefaultDateRange)

--- a/frontend/src/AppRouter.res
+++ b/frontend/src/AppRouter.res
@@ -8,7 +8,7 @@ type error = {
   reason: string,
 }
 
-let route = (url: ReasonReactRouter.url) =>
+let route = (url: RescriptReactRouter.url) =>
   switch url.path {
   | list{} => Ok(Main)
   | list{orgName, repoName} => Ok(Repo({repoId: orgName ++ "/" ++ repoName, benchmarkName: None}))
@@ -53,6 +53,6 @@ let path = route =>
     "/" ++ repoId ++ "/pull/" ++ Belt.Int.toString(pullNumber) ++ "/benchmark/" ++ benchmarkName
   }
 
-let useRoute = () => ReasonReactRouter.useUrl()->route
+let useRoute = () => RescriptReactRouter.useUrl()->route
 
-let go = route => ReasonReact.Router.push(path(route))
+let go = route => RescriptReactRouter.push(path(route))

--- a/frontend/src/Components.res
+++ b/frontend/src/Components.res
@@ -951,7 +951,7 @@ module Link = {
           (!(event->ReactEvent.Mouse.metaKey) && !(event->ReactEvent.Mouse.shiftKey)))))
         ) {
           event->ReactEvent.Mouse.preventDefault
-          href->ReasonReactRouter.push
+          href->RescriptReactRouter.push
         }}>
       icon_svg text
     </a>

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -300,6 +300,6 @@ let make = React.memo((
 
   <div className={Sx.make(sx)}>
     <Row spacing=#between alignY=#top sx={[Sx.mb.xl]}> {left} {right} </Row>
-    <div className={Sx.make(graphSx)} ref={ReactDOMRe.Ref.domRef(graphDivRef)} />
+    <div className={Sx.make(graphSx)} ref={ReactDOM.Ref.domRef(graphDivRef)} />
   </div>
 })

--- a/frontend/src/Litepicker.res
+++ b/frontend/src/Litepicker.res
@@ -51,6 +51,6 @@ let make = (~sx as uSx=[], ~startDate=?, ~endDate=?, ~onSelect=?) => {
   let sx = Array.append(uSx, containerSx)
   <Row sx alignX=#center alignY=#center>
     <Icon svg=Icon.calendar />
-    <input className={Sx.make(elementSx)} ref={ReactDOMRe.Ref.domRef(elementRef)} />
+    <input className={Sx.make(elementSx)} ref={ReactDOM.Ref.domRef(elementRef)} />
   </Row>
 }

--- a/frontend/src/Rx.res
+++ b/frontend/src/Rx.res
@@ -28,6 +28,6 @@ let bool = x => React.string(string_of_bool(x))
 let string = React.string
 let text = React.string
 let array = (~empty=React.null, xs) => Array.length(xs) == 0 ? empty : React.array(xs)
-let list = l => ReasonReact.array(Array.of_list(l))
+let list = l => Array.of_list(l)
 
 let eventValue = e => ReactEvent.Form.target(e)["value"]

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -86,8 +86,8 @@ module BenchmarksMenu = {
 module SidebarMenu = {
   @react.component
   let make = (~repoId, ~selectedPull=?, ~selectedBenchmarkName=?) => {
-    let ({ReasonUrql.Hooks.response: response}, _) = {
-      ReasonUrql.Hooks.useQuery(
+    let ({ReScriptUrql.Hooks.response: response}, _) = {
+      ReScriptUrql.Hooks.useQuery(
         ~query=module(SidebarMenuData),
         {
           repoId: repoId,

--- a/frontend/src/index.res
+++ b/frontend/src/index.res
@@ -1,17 +1,17 @@
-let fetchOptions = ReasonUrql.Client.FetchOpts(
+let fetchOptions = ReScriptUrql.Client.FetchOpts(
   Fetch.RequestInit.make(
     ~headers=Fetch.HeadersInit.make({"X-Hasura-Admin-Secret": "zbNoMU69kxiw"}),
     (),
   ),
 )
 
-let client = ReasonUrql.Client.make(
+let client = ReScriptUrql.Client.make(
   ~url="http://autumn.ocamllabs.io:8080/v1/graphql",
   ~fetchOptions,
   (),
 )
 
-ReactDOMRe.renderToElementWithId(
-  <ReasonUrql.Context.Provider value=client> <App /> </ReasonUrql.Context.Provider>,
-  "root",
+ReactDOM.render(
+  <ReScriptUrql.Context.Provider value=client> <App /> </ReScriptUrql.Context.Provider>,
+  ReactDOM.querySelector("#root")->Belt.Option.getExn,
 )

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -321,23 +321,35 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
 
-"@reasonml-community/graphql-ppx@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@reasonml-community/graphql-ppx/-/graphql-ppx-1.0.2.tgz#5641413a8873d412dc6a0b00a1fe273323406fb8"
-  integrity sha512-A4KURw/hpGWvW6Dkmg8LpF3GlWZ1FCyP3MhHLUlmViboZ51bRSnO0lU4hK8TE6x5/B2Uik59YACJZX47VqWmOw==
+"@reasonml-community/graphql-ppx@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@reasonml-community/graphql-ppx/-/graphql-ppx-1.2.0.tgz#5a51021dd43c3a090da34d2dfa22b2257fdb9049"
+  integrity sha512-CKTzl/DZNT0QgpKjpi0Fij2R4r9c/oT+M8mEWYnNidaLDcFX7ZfcvmJA4ZhPYXRD6AGUO3cS1zQOJZSuJHKogQ==
+
+"@rescript/react@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@rescript/react/-/react-0.10.1.tgz#ddce66ba664a104354d559c350ca4ebf17ab5a26"
+  integrity sha512-5eIfGnV1yhjv03ktK6fQ6iEfsZKXKXXrq5hx4+ngEY4R/RU8o/oH9ne375m9RJMugV/jsE8hMoEeSSg2YQy3Ag==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@urql/core@^1.16.0":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-1.16.1.tgz#a41487dd4436cbdc92fce714c6c1fc04315761d3"
-  integrity sha512-lcEMCS/rB+ug7jKSRDVZIsqNhZxRooTNa1kHfvSjJT2k4SXDyPmjNSfXBUJF2pDJmvv9EIKl9Tk0AF1CvG3Q/g==
+"@urql/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-2.0.0.tgz#b4936dd51fe84cb570506d9ee2579149689f7535"
+  integrity sha512-Qj24CG8ullqZZsYmjrSH0JhH+nY7kj8GbVbA9si3KUjlYs75A/MBQU3i97j6oWyGldDBapyis2CfaQeXKbv8rA==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
+
+"@urql/rescript@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@urql/rescript/-/rescript-4.0.0.tgz#7b51b1daf5594b0dd923ed9f6b532457ce582dc1"
+  integrity sha512-RENLltLMpB9iiXG0DthjM669NhqzBaukGt7oxM/BnW5HLNspwF8kJtmUI3LYrGwZ0qQRiiu6vyOcMfYy85GZag==
+  dependencies:
+    bs-fetch "^0.6.2"
 
 "@vitejs/plugin-react-refresh@^1.3.1":
   version "1.3.1"
@@ -397,28 +409,28 @@ browserslist@^4.14.5:
     escalade "^3.1.1"
     node-releases "^1.1.67"
 
-bs-css-emotion@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/bs-css-emotion/-/bs-css-emotion-2.4.0.tgz#9d94348f6e2a0d8f661323b16b06cb047bac42cf"
-  integrity sha512-pM+i5709j0BXK50s9LqX6sdAKbkilkXBm6j0C38PduKUDv6c6GoklxMwDdVf/hG7VQqd9znWcvjCD/b8WjQdPA==
+bs-css-emotion@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/bs-css-emotion/-/bs-css-emotion-2.5.1.tgz#ab457544332d63d1fa69ea950a71dcf2ace88b1d"
+  integrity sha512-CQyyj8LlYdo5NeiBx2PC9v7Et/BQbj/thaHv84DFvrOivu9kk6A4rr5/Gl6HuAE77S4G0QmuuN2IRaE+vo3b+g==
   dependencies:
-    bs-css "13.4.0"
-    emotion "^10.0.7"
+    bs-css "14.0.1"
+    emotion "^10.0.0"
 
-bs-css@13.4.0:
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/bs-css/-/bs-css-13.4.0.tgz#0918841c2812b0ae0ce1c9c569b98347ae25aa48"
-  integrity sha512-/vmbAeccXdngc9Ky2rXYtEoO9C5cqgrlUjnoseltFjY5S+HaI2PBFw+bIJ+pp5iTaJmn5Ip3cNj+Vsdex4ULaA==
+bs-css@14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/bs-css/-/bs-css-14.0.1.tgz#983394472d825c590a8f91230bfcb082e9474670"
+  integrity sha512-gNaKpU7sQKjyVCTgNa+ReHt0yAx19HcOYbGU4Sg7Jlv04NXK3FCvqffF60xb+x+jMMquOTLIj4VyQPiPSZ82Nw==
 
 bs-fetch@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.6.2.tgz#37d982e9f79b9bc44c23e87ae78ccbee1f869adf"
   integrity sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg==
 
-bs-platform@^8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-8.4.2.tgz#778dabd1dfb3bc95e0086c58dabae74e4ebdee8a"
-  integrity sha512-9q7S4/LLV/a68CweN382NJdCCr/lOSsJR3oQYnmPK98ChfO/AdiA3lYQkQTp6T+U0I5Z5RypUAUprNstwDtMDQ==
+bs-platform@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.2.tgz#a6eac70eb8924a322556dacaccbfbc9b2a0d3a37"
+  integrity sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -506,7 +518,7 @@ electron-to-chromium@^1.3.621:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.631.tgz#b28ebc7bfb348bb0aede2fae8888d775ddb6f5ee"
   integrity sha512-mPEG/52142po0XK1jQkZtbMmp38MZtQ3JDFItYxV65WXyhxDYEQ54tP4rb93m0RbMlZqQ+4zBw2N7UumSgGfbA==
 
-emotion@^10.0.7:
+emotion@^10.0.0:
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.27.tgz#f9ca5df98630980a23c819a56262560562e5d75e"
   integrity sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==
@@ -521,10 +533,10 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-esbuild@^0.8.52:
-  version "0.8.54"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.54.tgz#2f32ff80e95c69a0f25b799d76a27c05e2857cdf"
-  integrity sha512-DJH38OiTgXJxFb/EhHrCrY8eGmtdkTtWymHpN9IYN9AF+4jykT0dQArr7wzFejpVbaB0TMIq2+vfNRWr3LXpvw==
+esbuild@^0.9.3:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.7.tgz#ea0d639cbe4b88ec25fbed4d6ff00c8d788ef70b"
+  integrity sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -566,10 +578,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-graphql@^15.4.0:
-  version "15.4.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
-  integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
+graphql@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
+  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -708,39 +720,27 @@ postcss@^8.2.1:
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
-react-dom@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
-  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.1"
+    scheduler "^0.20.2"
 
 react-refresh@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
   integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
-react@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-reason-react@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.9.1.tgz#30a887158200b659aa03e2d75ff4cc54dc462bb0"
-  integrity sha512-nlH0O2TDy9KzOLOW+vlEQk4ExHOeciyzFdoLcsmmiit6hx6H5+CVDrwJ+8aiaLT/kqK5xFOjy4PS7PftWz4plA==
-
-reason-urql@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/reason-urql/-/reason-urql-3.4.0.tgz#a0ff717c7d367800344303aec3a6577357071af6"
-  integrity sha512-GzErIy2OqUdaMxNlWaaa1zbgw/auBqX/NE70O/Qc/rhVpgKM/+2OvI2oKG0vTq7IuA+l9J+9V/Uy8pO2PtOp+Q==
-  dependencies:
-    bs-fetch "^0.6.2"
 
 regenerator-runtime@^0.13.4:
   version "0.13.7"
@@ -780,10 +780,10 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-scheduler@^0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
-  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -815,20 +815,20 @@ to-fast-properties@^2.0.0:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
-urql@^1.11.6:
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.11.6.tgz#6b6b60093fc9ef142915938a8dbd3cc84e2dd195"
-  integrity sha512-PpXzZiCKStcg52M9hJZTbcU5wIvQlYqu0vVofdaEv144JbvOhKIwzcX0+qkc3yJMyDm2isYo4D1vQQY+meRVqg==
+urql@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-2.0.1.tgz#16c024ab0340328001b0c400ebe1368887af3823"
+  integrity sha512-UTYLaMMw/N2iM2nHbcZ1XvN+opZxtWKwJaczV+MAco8buFpR3JR9CFrgKvx9p4uz+EayqQ69LZTWreJx+c196w==
   dependencies:
-    "@urql/core" "^1.16.0"
+    "@urql/core" "^2.0.0"
     wonka "^4.0.14"
 
-vite@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.0.4.tgz#063532a4139b59a067297d8ebb5960d450907a09"
-  integrity sha512-+PP89D7AKXFE4gps8c5+4eP5yXTh5qCogjdYX7iSsIxbLZAa26JoGSq6OLk0qdb/fqDh7gtJqGiLbG2V6NvkKQ==
+vite@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.1.4.tgz#66396823701e54cf3bfb9f73dbd386c9b4329c86"
+  integrity sha512-j/p0RZQvNY/auSPfazsDfo1PHtFp8ktwXPbzI6NqplzHcR3Cn/dfQWiMxL6zp8j9IWdcJP1Zfms7mxruBhStJw==
   dependencies:
-    esbuild "^0.8.52"
+    esbuild "^0.9.3"
     postcss "^8.2.1"
     resolve "^1.19.0"
     rollup "^2.38.5"


### PR DESCRIPTION
`reason-urql` is now compatible with `urql@2` and [has been renamed to `@urql/rescript`](https://github.com/FormidableLabs/rescript-urql/releases). It now supports the new `@rescript/react` package.

I also updated a few other dependencies such as `vite` and `bs-css`.