### PR TITLE
Add a service check for migration docker container

### DIFF
--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -20,6 +20,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-migrate:
+        condition: service_started
     restart: always
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://docker:docker@db:5432/docker


### PR DESCRIPTION
Addresses #97. Not a full solution because adding a healthcheck results in an unhealthy error problem. This is the healthcheck I added for checking if "applied" existed in `omigrate ls`.

```
"CMD-SHELL", "omigrate ls --source /app/db/migrations --database postgresql://docker:${OCAML_BENCH_DB_PASSWORD?required}@db:5432/docker | grep -wc \"applied\" "]
```