### PR TITLE
Add current-bench-bechamel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 local-test-repo/.git
 *.env
+_build

--- a/current-bench-bechamel/current-bench-bechamel.opam
+++ b/current-bench-bechamel/current-bench-bechamel.opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Convert bechamel results into current-bench JSON format"
+maintainer: ["Rizo I. <rizo@tarides.com>" "Gargi Sharma <gargi@tarides.com>"]
+authors: ["Rizo I. <rizo@tarides.com>"]
+homepage: "https://github.com/ocurrent/current-bench"
+bug-reports: "https://github.com/ocurrent/current-bench/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "bechamel"
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/current-bench.git"
+

--- a/current-bench-bechamel/current_bench_bechamel.ml
+++ b/current-bench-bechamel/current_bench_bechamel.ml
@@ -1,0 +1,52 @@
+type 'a result = (string, 'a) Hashtbl.t
+
+type 'a results = (string, 'a result) Hashtbl.t
+
+let process_results results =
+  let metrics_by_test = Hashtbl.create 16 in
+  Hashtbl.iter
+    (fun metric_name result ->
+      Hashtbl.iter
+        (fun test_name ols ->
+          let metrics =
+            try Hashtbl.find metrics_by_test test_name
+            with Not_found -> Hashtbl.create 16
+          in
+          Hashtbl.add metrics metric_name ols;
+          Hashtbl.replace metrics_by_test test_name metrics)
+        result)
+    results;
+  metrics_by_test
+
+
+let json_of_ols ols =
+  match Bechamel.Analyze.OLS.estimates ols with
+  | Some [ x ] -> `Float x
+  | Some estimates -> `List (List.map (fun x -> `Float x) estimates)
+  | None -> `List []
+
+
+let json_of_ols_results ?name (results : Bechamel.Analyze.OLS.t results) :
+    Yojson.Safe.t =
+  let metrics_by_test = process_results results in
+  let results =
+    metrics_by_test |> Hashtbl.to_seq
+    |> Seq.map (fun (test_name, metrics) ->
+           let metrics =
+             metrics |> Hashtbl.to_seq
+             |> Seq.map (fun (metric_name, ols) ->
+                    (metric_name, json_of_ols ols))
+             |> List.of_seq
+             |> fun bindings -> `Assoc bindings
+           in
+           `Assoc [ ("name", `String test_name); ("metrics", metrics) ])
+    |> List.of_seq
+    |> fun items -> `List items
+  in
+  let bindings = [ ("results", results) ] in
+  let bindings =
+    match name with
+    | Some name -> ("name", `String name) :: bindings
+    | None -> bindings
+  in
+  `Assoc bindings

--- a/current-bench-bechamel/current_bench_bechamel.mli
+++ b/current-bench-bechamel/current_bench_bechamel.mli
@@ -1,0 +1,9 @@
+type 'a result = (string, 'a) Hashtbl.t
+
+type 'a results = (string, 'a result) Hashtbl.t
+
+val json_of_ols_results :
+  ?name:string -> Bechamel.Analyze.OLS.t results -> Yojson.Safe.t
+(** [json_of_ols_results ?name ols] is a JSON value containing a list of test
+    metrics encoded from the OLS results. [name] is the name of the benchmark,
+    will be omitted by default. *)

--- a/current-bench-bechamel/dune
+++ b/current-bench-bechamel/dune
@@ -1,0 +1,4 @@
+(library
+  (public_name current-bench-bechamel)
+  (name current_bench_bechamel)
+  (libraries bechamel yojson))

--- a/current-bench-bechamel/dune-project
+++ b/current-bench-bechamel/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.8)
+(name current-bench-bechamel)


### PR DESCRIPTION
This adds a helper conversion library for [bechamel](https://github.com/mirage/bechamel).

The interface is fairly simple. `Current_bench_bechamel.json_of_ols_results` produces a JSON object compatible with format expected by current-bench.

Below is the example output for the [list](https://github.com/mirage/bechamel/blob/3e1887305badf5dcc1ecb06beb5b023f55b4193c/examples/list.ml) example found in bechamel repo.

#### Default terminal output
```
╭─────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name         │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├─────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  list 0     │             0.0000 mjw/run│             3.0001 mnw/run│              2.2619 ns/run│
│  list 10    │             0.0002 mjw/run│            12.0001 mnw/run│              5.3421 ns/run│
│  list 100   │             0.0191 mjw/run│           102.0005 mnw/run│             24.5672 ns/run│
│  list 1000  │             1.9189 mjw/run│          1002.0053 mnw/run│            243.3148 ns/run│
│  list 400   │             0.3056 mjw/run│           402.0021 mnw/run│             96.9438 ns/run│
╰─────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯
```

#### Current-bench output

```json
{                    
  "results": [
    {
      "name": "list 1000",
      "metrics": {
        "monotonic-clock": 243.2637296395763,
        "minor-allocated": 1002.0052699727818,
        "major-allocated": 1.9172055128707965
      }
    },
    {
      "name": "list 0",
      "metrics": {
        "monotonic-clock": 2.27107018701659,
        "minor-allocated": 3.0000508574094127,
        "major-allocated": 9.258983672380356e-12
      }
    },
    {
      "name": "list 10",
      "metrics": {
        "monotonic-clock": 5.347919738950992,
        "minor-allocated": 12.000113881006632,
        "major-allocated": 0.00020589389443048122
      }
    },
    {
      "name": "list 400",
      "metrics": {
        "monotonic-clock": 97.26167335024918,
        "minor-allocated": 402.00208592324526,
        "major-allocated": 0.3058356218412759
      }
    },
    {
      "name": "list 100",
      "metrics": {
        "monotonic-clock": 24.536509571811653,
        "minor-allocated": 102.0005223294557,
        "major-allocated": 0.01912587791521939
      }
    }
  ]
}
```