### PR TITLE
Pass arg value to frontend docker instead of env.

### DIFF
--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -35,14 +35,14 @@ services:
     build: 
       context: ../frontend
       args:
+        VITE_OCAML_BENCH_PIPELINE_URL: ${OCAML_BENCH_PIPELINE_URL?required}
         VITE_OCAML_BENCH_GRAPHQL_URL: ${OCAML_BENCH_GRAPHQL_URL?required}
     ports:
       ["${OCAML_BENCH_FRONTEND_PORT?required}:${OCAML_BENCH_FRONTEND_PORT?required}"]
+
     restart: always
     depends_on:
     - "graphql-engine"
-    environment:
-        VITE_OCAML_BENCH_PIPELINE_URL: ${OCAML_BENCH_PIPELINE_URL?required}
   pipeline:
     build:
       context: ../pipeline

--- a/environments/production.docker-compose.yaml
+++ b/environments/production.docker-compose.yaml
@@ -37,14 +37,13 @@ services:
     build: 
       context: ../frontend
       args:
+        VITE_OCAML_BENCH_PIPELINE_URL: ${OCAML_BENCH_PIPELINE_URL?required}
         VITE_OCAML_BENCH_GRAPHQL_URL: ${OCAML_BENCH_GRAPHQL_URL?required}
     ports:
     - "${OCAML_BENCH_FRONTEND_PORT?required}:${OCAML_BENCH_FRONTEND_PORT?required}"
     restart: always
     depends_on:
     - "graphql-engine"
-    environment:
-      VITE_OCAML_BENCH_PIPELINE_URL: ${OCAML_BENCH_PIPELINE_URL?required}
   pipeline:
     build:
       context: ../pipeline

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,7 @@
 FROM node:lts AS builder
 
 ARG VITE_OCAML_BENCH_GRAPHQL_URL
+ARG VITE_OCAML_BENCH_PIPELINE_URL
 
 # set working directory
 WORKDIR /app
@@ -13,6 +14,7 @@ RUN yarn install
 COPY . /app/
 
 RUN echo "VITE_OCAML_BENCH_GRAPHQL_URL=${VITE_OCAML_BENCH_GRAPHQL_URL}" > /app/.env
+RUN echo "VITE_OCAML_BENCH_PIPELINE_URL=${VITE_OCAML_BENCH_PIPELINE_URL}" > /app/.env
 
 RUN yarn build
 RUN yarn bundle


### PR DESCRIPTION
The frontend image needs the arg value (which is available at build time) because the eventual container running is an nginx image, and the env variable is not available to the frontend image and shows up as `undefined` as mentioned in #127 