### PR TITLE
Add bench target for test benchmarks pipeline.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ stop-production:
 		down
 
 # Make sure the fake testing repo is initialised.
+.SILENT: ./local-test-repo/.git
 ./local-test-repo/.git:
 	cd ./local-test-repo/ && git init && git add . && git commit -m "Initial commit."
 

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,7 @@ start-development: ./local-test-repo/.git
 		up \
 		--remove-orphans \
 		--build
+
+.PHONY: bench
+bench: ./local-test-repo/.git
+	@cd ./local-test-repo/ && make -s bench

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ stop-production:
 		down
 
 # Make sure the fake testing repo is initialised.
-.SILENT: ./local-test-repo/.git
 ./local-test-repo/.git:
 	cd ./local-test-repo/ && git init && git add . && git commit -m "Initial commit."
 
@@ -33,5 +32,5 @@ start-development: ./local-test-repo/.git
 		--build
 
 .PHONY: bench
-bench: ./local-test-repo/.git
+bench: 
 	@cd ./local-test-repo/ && make -s bench


### PR DESCRIPTION
Adding a bench target that runs `make bench` which cats the output from the Makefile in `local-test-repo`.