### PR TITLE
set subtitle min-height

### DIFF
--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -403,9 +403,9 @@ let make = React.memo((
   | Some(title) =>
     <Column spacing=Sx.lg sx=[Sx.w.auto]>
       <Text sx=[Sx.leadingNone, Sx.text.bold, Sx.text.xl]> title </Text>
-      {Rx.onSome(subTitle, subTitle =>
-        <Text sx=[Sx.leadingNone, Sx.text.sm, Sx.text.color(Sx.gray600)]> subTitle </Text>
-      )}
+      <Text sx=[Sx.leadingNone, Sx.text.sm, Sx.text.color(Sx.gray600), [Css.minHeight(#em(1.0))]]>
+        {Belt.Option.getWithDefault(subTitle, "")}
+      </Text>
     </Column>
   | None => React.null
   }


### PR DESCRIPTION
This PR adds a `min-height` to the subtitle so that even if it's empty, space is reserved and graphs keep the same height.

### Before
<img width="1663" alt="Screenshot 2021-05-30 at 07 34 31" src="https://user-images.githubusercontent.com/5595092/120093359-fabd8680-c119-11eb-9861-56cfdd52edac.png">

### After 

![image](https://user-images.githubusercontent.com/5595092/120093406-55ef7900-c11a-11eb-9f59-c85001b42006.png)
