### PR TITLE
lazily load graphs

### DIFF
--- a/frontend/src/BeltHelpers.res
+++ b/frontend/src/BeltHelpers.res
@@ -38,9 +38,10 @@ module Array = {
     loop(len - 1, None)
   }
 
-  let push = (arr, item) => {
-    ignore(Js.Array.push(item, arr))
-    arr
+  let add = (arr, item) => {
+    let newArr = Belt.Array.sliceToEnd(arr, 0)
+    ignore(Js.Array.push(item, newArr))
+    newArr
   }
 
   let last = arr => Belt.Array.get(arr, Belt.Array.length(arr) - 1)

--- a/frontend/src/BenchmarkData.res
+++ b/frontend/src/BenchmarkData.res
@@ -21,8 +21,8 @@ let add = (
 
   // Update
   let row = LineGraph.DataRow.with_date(runAt, value)
-  let timeseries = BeltHelpers.Array.push(timeseries, row)
-  let metadata = BeltHelpers.Array.push(metadata, {"commit": commit, "runAt": runAt})
+  let timeseries = BeltHelpers.Array.add(timeseries, row)
+  let metadata = BeltHelpers.Array.add(metadata, {"commit": commit, "runAt": runAt})
 
   // Wrap
   let byMetricName = Map.String.set(byMetricName, metricName, (timeseries, metadata))

--- a/frontend/src/Hooks.res
+++ b/frontend/src/Hooks.res
@@ -1,0 +1,30 @@
+
+let useIntersection = (
+  ref: React.ref<Js.Nullable.t<Dom.element>>,
+  options: IntersectionObserver.intersectionOption,
+) => {
+  let (intersectionObserverEntry, setIntersectionObserverEntry) = React.useState(() => None)
+
+  React.useEffect4(() => {
+    switch Js.Nullable.toOption(ref.current) {
+    | None => None
+    | Some(domRef) => {
+        let handler = (entries, _observer) => {
+          setIntersectionObserverEntry(_ => Some(entries[0]))
+        }
+
+        let observer = IntersectionObserver.make(handler, options)
+        let () = IntersectionObserver.observe(observer, domRef)
+
+        Some(
+          () => {
+            setIntersectionObserverEntry(_ => None)
+            let () = IntersectionObserver.disconnect(observer)
+          },
+        )
+      }
+    }
+  }, (ref.current, options.root, options.rootMargin, options.threshold))
+
+  intersectionObserverEntry
+}

--- a/frontend/src/IntersectionObserver.res
+++ b/frontend/src/IntersectionObserver.res
@@ -1,0 +1,27 @@
+type t = Dom.intersectionObserver
+
+module Entry = {
+  type t = Dom.intersectionObserverEntry
+  @get external isIntersecting: t => bool = "isIntersecting"
+}
+
+type intersectionOption = {
+  root: Js.Nullable.t<Dom.element>,
+  rootMargin: option<string>,
+  threshold: option<array<float>>,
+}
+
+@obj
+external makeOption: (
+  ~root: Js.Nullable.t<Dom.element>=?,
+  ~rootMargin: string=?,
+  ~threshold: array<float>=?,
+  unit,
+) => intersectionOption = ""
+
+@new
+external make: (@uncurry (array<Entry.t>, t) => unit, intersectionOption) => t =
+  "IntersectionObserver"
+
+@send external disconnect: t => unit = "disconnect"
+@send external observe: (t, Dom.element) => unit = "observe"

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -99,9 +99,7 @@ module DataRow = {
   }
 
   let add_value = (row: t, value: value): t => {
-    let newRow = row->Belt.Array.sliceToEnd(0)
-    Js.Array.push(value, newRow)->ignore
-    newRow
+    row->BeltHelpers.Array.add(value)
   }
 }
 
@@ -317,9 +315,7 @@ let make = React.memo((
   }
   let data = addSeries(data, constantSeries)
   let labels = labels->Belt.Option.map(labels => {
-    let newLabels = labels->Belt.Array.sliceToEnd(0)
-    Js.Array.push("std-dev", newLabels)->ignore
-    newLabels
+    labels->BeltHelpers.Array.add("std-dev")
   })
 
   // Dygraph does not display the last tick, so a dummy value
@@ -329,7 +325,7 @@ let make = React.memo((
   let data = switch lastRow {
   | Some(lastRow) =>
     let lastIndex = DataRow.unsafe_get_index(lastRow)
-    data->Belt.Array.sliceToEnd(0)->BeltHelpers.Array.push(DataRow.nan2(~index=lastIndex + 1))
+    data->BeltHelpers.Array.add(DataRow.nan2(~index=lastIndex + 1))
   | None => data
   }
 


### PR DESCRIPTION
This PR uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to render the graphs only when they are in the viewport. This should significantly improve the performance for repositories that contain lots of graphs (e.g. `mirage/repr`)