### PR TITLE
Add pool to pread

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -101,8 +101,8 @@ let pipeline ~slack_path ~conninfo ?branch ?pull_number ~dockerfile ~tmpfs
     in
     let repo_info = owner ^ "/" ^ repository in
     let current_output =
-      Docker_util.pread_log ~run_args current_image ~repo_info ?pull_number
-        ?branch ~commit
+      Docker_util.pread_log ~pool ~run_args current_image ~repo_info
+        ?pull_number ?branch ~commit
         ~args:
           [
             "/usr/bin/setarch"; "x86_64"; "--addr-no-randomize"; "make"; "bench";


### PR DESCRIPTION
There's contention of resources in `pread` because of which there's interleaving when running the benchmarks. This partially fixes #141 but doesn't account for why the first instance as mentioned in the issue took 23 minutes idling.