### PR TITLE
Fix duplication in development docker-compose file.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -45,6 +45,13 @@ Edit the `./environments/development.env` file and adjust the configurations var
 
 Make sure that the `./environments/development.env` exists and has the correct configuration.
 
+Before you start your docker containers for the first time, you'll
+need to create an external docker volume, like this:
+
+```
+docker volume create --name=current-bench-data
+```
+
 Start the docker-compose environment:
 
 ```

--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -51,18 +51,10 @@ services:
       args:
         TARGET_ARCH: ${OCAML_BENCH_TARGET_ARCH?required}
     volumes:
-      - current-bench-data:/app/current-bench-data
       # Mount the source code of the test project to allow local testing.
+      - current-bench-data:/app/current-bench-data
       - ../local-test-repo:/app/local-test-repo
       - /var/run/docker.sock:/var/run/docker.sock
-    ports:
-      [
-        "${OCAML_BENCH_PIPELINE_PORT?required}:${OCAML_BENCH_PIPELINE_PORT?required}",
-      ]
-    # Mount the source code of the test project to allow local testing.
-    - current-bench-data:/app/current-bench-data:ro
-    - ../local-test-repo:/app/local-test-repo
-    - /var/run/docker.sock:/var/run/docker.sock
     ports: ["${OCAML_BENCH_PIPELINE_PORT?required}:${OCAML_BENCH_PIPELINE_PORT?required}"]
     command:
       - "current-bench-pipeline"


### PR DESCRIPTION
This morning I tried setting this project up locally and ran into a couple problems while following the instructions in `HACKING.md`. This change captures what I needed to do in order to get development docker containers running. (Hopefully this is helpful, if not please let me know.)

When I ran `make start-development`, I saw this error:
```
docker-compose \
		--project-name="current-bench" \
		--file=./environments/development.docker-compose.yaml \
		--env-file=./environments/development.env \
		up \
		--remove-orphans \
		--build
ERROR: yaml.parser.ParserError: while parsing a block mapping
  in "././environments/development.docker-compose.yaml", line 49, column 5
expected <block end>, but found '-'
  in "././environments/development.docker-compose.yaml", line 63, column 5
make: *** [start-development] Error 1
```

When I took a look at the definition for the `pipeline` container [here](https://github.com/ocurrent/current-bench/blob/main/environments/development.docker-compose.yaml#L53-L66), I noticed that it has two definitions for `ports`.  I think what happened is that a prior edit duplicated the lines defining volumes and ports for `pipeline`, creating a syntax error. I tried to dedupe them, keeping the more recent version of the `current-bench-data` volume.

I also had a small problem starting the containers because the `current-bench-data` volume is marked as external, but didn't exist. Running a `docker volume create` command beforehand seemed to fix this problem, so I added a comment about this in the setup steps.

Also, it looks like I can't load the frontend on http://localhost:8082, because although the docker-compose file maps port 8082 on localhost to port 8082 on `frontend`, the nginx configuration for `frontend` only listens on port 80. I could fix that by adjusting the nginx config to listen on more ports, or by modifying the docker-compose file to map localhost:8082 to frontend:80. 