### PR TITLE
manage name collisions in the current-bench pipeline

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -9,9 +9,12 @@ module Benchmark = Models.Benchmark
 
 let ( >>| ) x f = Current.map f x
 
-let is_duplicate elem lst = lst |>
-  List.map (fun x -> if x = elem then 1 else 0) |>
-  List.fold_left (fun acc x -> acc + x) 0 |> fun x -> x > 1
+let is_duplicate elem lst =
+  lst
+  |> List.map (fun x -> if x = elem then 1 else 0)
+  |> List.fold_left (fun acc x -> acc + x) 0
+  |> fun x -> x > 1
+
 module Source = struct
   type github = {
     token : Fpath.t;
@@ -123,19 +126,25 @@ let pipeline ~slack_path ~conninfo ?branch ?pull_number ~dockerfile ~tmpfs
     Logs.debug (fun log -> log "Benchmark output:\n%s" output);
     let () =
       let db = new Postgresql.connection ~conninfo () in
-      output
-      |> Json_util.parse_many
-      |> fun output_json_lst ->
-          let benchmark_name_lst =
-            List.map (fun output_json -> 
-              Yojson.Safe.Util.(member "name" output_json) 
-              |> Yojson.Safe.Util.to_string_option) output_json_lst
-          in
-          List.iter (fun x -> 
-            if is_duplicate x benchmark_name_lst then 
-              raise (Failure "Same benchmark name, please change it to unique benchmark name") 
-              else ()) benchmark_name_lst |> fun _ ->
-        output_json_lst
+      output |> Json_util.parse_many |> fun output_json_lst ->
+      let benchmark_name_lst =
+        List.map
+          (fun output_json ->
+            Yojson.Safe.Util.(member "name" output_json)
+            |> Yojson.Safe.Util.to_string_option)
+          output_json_lst
+      in
+      List.iter
+        (fun x ->
+          if is_duplicate x benchmark_name_lst then
+            raise
+              (Failure
+                 "Same benchmark name, please change it to unique benchmark \
+                  name")
+          else ())
+        benchmark_name_lst
+      |> fun _ ->
+      output_json_lst
       |> List.iter (fun output_json ->
              let benchmark_name =
                Yojson.Safe.Util.(member "name" output_json)


### PR DESCRIPTION
This PR aims to resolve https://github.com/ocurrent/current-bench/issues/62, it errors out when there is a name collision in the toplevel name field of the benchmark json.

https://github.com/ocurrent/current-bench/issues/62 also states that the benchmark name is a NULL type in the database schema - https://github.com/ocurrent/current-bench/blob/12b86dc73edaa94a81ace014b7b845b2cc4dc9c2/pipeline/db/migrations/20210013150054_add_benchmarks_table.up.sql#L7

Which means it is currently optional and can be left out as NULL in the database table and the field is omitted in the json produced in the `pread_log` of the current-bench UI.