### PR TITLE
Fix run_at = now for the local dev repository

### DIFF
--- a/pipeline/.ocamlformat
+++ b/pipeline/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.18.0
+version = 0.19.0
 profile = conventional
 parse-docstrings = true
 break-infix = fit-or-vertical

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -120,13 +120,13 @@ let pipeline ~slack_path ~conninfo ?branch ?pull_number ~dockerfile ~tmpfs
       @ docker_cpuset_cpus
       @ docker_cpuset_mems
     in
-    let run_at = Ptime_clock.now () in
     let* commit =
       match head with
       | `Github api_commit -> Current.return (Github.Api.Commit.hash api_commit)
       | `Local commit -> commit >>| Git.Commit.hash
     in
     let repo_info = owner ^ "/" ^ repository in
+    let run_at = Ptime_clock.now () in
     let current_output =
       Docker_util.pread_log ~pool ~run_args current_image ~repo_info
         ?pull_number ?branch ~commit


### PR DESCRIPTION
When current-bench is running in development mode, the pipeline for `local-test-repo` is created with a constant `run_at` equal to the launch time: every commit has the same `run_at`. By computing `run_at` later in the pipeline (after a bind), we get the true timing (just like in production).