### PR TITLE
Add a unique constraint to prevent duplicates in the db

### DIFF
--- a/pipeline/db/migrations/20210303145089_add_unique_constraint_to_benchmarks.down.sql
+++ b/pipeline/db/migrations/20210303145089_add_unique_constraint_to_benchmarks.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE benchmarks
+DROP CONSTRAINT prevent_duplicates;

--- a/pipeline/db/migrations/20210303145089_add_unique_constraint_to_benchmarks.up.sql
+++ b/pipeline/db/migrations/20210303145089_add_unique_constraint_to_benchmarks.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE benchmarks
+ADD CONSTRAINT prevent_duplicates UNIQUE(commit, test_name, run_job_id);

--- a/pipeline/lib/models.ml
+++ b/pipeline/lib/models.ml
@@ -91,7 +91,7 @@ INSERT INTO
   benchmarks(run_at, duration, repo_id, commit, branch, pull_number, build_job_id, run_job_id, benchmark_name, test_name,  metrics)
 VALUES
   (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-  ON CONFLICT DO NOTHING
+  ON CONFLICT (commit, test_name, run_job_id) DO NOTHING
 |}
         run_at duration repository commit branch pull_number build_job_id
         run_job_id benchmark_name test_name metrics


### PR DESCRIPTION
Ocurrent triggers a lot of same runs, with same job_id and same everything else at the moment which creates a lot of commits, this constraint allows us to prevent that.