### PR TITLE
 Make creating new migrations using pipeline container easier 

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -127,6 +127,16 @@ omigrate: [INFO] Version 20210202135643 has already been applied
 ...
 ```
 
+### Creating new migrations
+
+New migrations can be created using the `omigrate create` command, when the
+pipeline container is running.
+
+
+```
+$ docker exec -it current-bench_pipeline_1 omigrate create --verbose --dir=/app/db/migrations add_version_column_to_benchmarks
+```
+
 ## Testing benchmarks locally
 
 Testing the OCaml Benchmarks project can be tricky because it operates as GitHub App in production. For local testing convenience the development environment includes a "shadow" git repository that can be used to trigger benchmark jobs.

--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -66,6 +66,7 @@ services:
       - current-bench-data:/app/current-bench-data
       - ../local-test-repo:/app/local-test-repo
       - /var/run/docker.sock:/var/run/docker.sock
+      - ../pipeline/db/migrations:/app/db/migrations
     ports: ["${OCAML_BENCH_PIPELINE_PORT?required}:${OCAML_BENCH_PIPELINE_PORT?required}"]
     command:
       - "current-bench-pipeline"


### PR DESCRIPTION
This commit mounts the ./pipeline/db/migrations directory as a volume in the
pipeline directory. This allows the `omigrate` command to be run in the
pipeline container, making the newly created migration files available in the
host machine immediately.

Previously, the migration files would only be available in the container and
would have to be manually copied to the host machine using the `docker cp`.