### PR TITLE
Fix broken down migration for add_duration_column_to_benchmarks

### DIFF
--- a/pipeline/db/migrations/20210101173805_add_duration_column_to_benchmarks.down.sql
+++ b/pipeline/db/migrations/20210101173805_add_duration_column_to_benchmarks.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE benchmarks DROP COLUMN duration;


### PR DESCRIPTION
The migration was added in ad094ce86751720a2c976150d1096fc4b8863869 but the
down migration was an empty file. This causes `omigrate down` to fail. The
current commit fixes this down migration to drop the duration column being
added in the up migration.