### PR TITLE
Fix redundant pipelines

### DIFF
--- a/pipeline/lib/models.ml
+++ b/pipeline/lib/models.ml
@@ -14,14 +14,14 @@ module Benchmark = struct
   }
 
   let make ?build_job_id ?run_job_id ~run_at ~duration ~benchmark_name
-      ~repository ~commit data =
+      ~repository data =
     let test_name = Yojson.Safe.Util.(member "name" data |> to_string) in
     let metrics = Yojson.Safe.Util.(member "metrics" data) in
     {
       run_at;
       duration;
       repo_id = Repository.id repository;
-      commit;
+      commit = Repository.commit_hash repository;
       branch = Repository.branch repository;
       pull_number = Repository.pull_number repository;
       build_job_id;

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -8,7 +8,6 @@ module Benchmark : sig
     duration:Ptime.span ->
     benchmark_name:string option ->
     repository:Repository.t ->
-    commit:string ->
     Yojson.Safe.t ->
     t
 

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -92,10 +92,10 @@ let github_status_of_state url = function
   | Error (`Active _) -> Github.Api.Status.v ~url `Pending
   | Error (`Msg m) -> Github.Api.Status.v ~url `Failure ~description:m
 
-let github_set_status ~repository head result =
-  match head with
-  | `Local _ -> Current.ignore_value result
-  | `Github head ->
+let github_set_status ~repository result =
+  match Repository.github_head repository with
+  | None -> Current.ignore_value result
+  | Some head ->
       let status_url = Repository.commit_status_url repository in
       result
       >>| github_status_of_state status_url
@@ -122,9 +122,10 @@ let db_save ~conninfo benchmark output =
          |> List.iter (Models.Benchmark.Db.insert db));
   db#finish
 
-let docker_make_bench ~run_args ~repository ~commit image =
-  let { Repository.branch; pull_number; _ } = repository in
-  let repo_info = Repository.info repository in
+let docker_make_bench ~run_args ~repository image =
+  let { Repository.branch; pull_number; _ } = repository
+  and repo_info = Repository.info repository
+  and commit = Repository.commit_hash repository in
   Docker_util.pread_log ~pool ~run_args image ~repo_info ?pull_number ?branch
     ~commit
     ~args:
@@ -137,14 +138,12 @@ let docker_make_bench ~run_args ~repository ~commit image =
         "eval $(opam env) && make bench";
       ]
 
-let pipeline ~conninfo ~run_args ~repository ~commit =
+let pipeline ~conninfo ~run_args ~repository =
   let src = Repository.src repository in
   let dockerfile = Custom_dockerfile.dockerfile ~pool ~run_args ~repository in
   let current_image = Docker.build ~pool ~pull:false ~dockerfile (`Git src) in
   let run_at = Ptime_clock.now () in
-  let current_output =
-    docker_make_bench ~run_args ~repository ~commit current_image
-  in
+  let current_output = docker_make_bench ~run_args ~repository current_image in
   let+ build_job_id = Current_util.get_job_id current_image
   and+ run_job_id = Current_util.get_job_id current_output
   and+ output = current_output in
@@ -152,41 +151,18 @@ let pipeline ~conninfo ~run_args ~repository ~commit =
   Logs.debug (fun log -> log "Benchmark output:\n%s" output);
   let () =
     db_save ~conninfo
-      (Benchmark.make ~duration ~run_at ~repository ~commit ?build_job_id
-         ?run_job_id)
+      (Benchmark.make ~duration ~run_at ~repository ?build_job_id ?run_job_id)
       output
   in
   output
 
-let fetch = function
-  | `Github api_commit ->
-      Git.fetch (Current.return (Github.Api.Commit.id api_commit))
-  | `Local commit -> commit
-
-let pipeline ~conninfo ~run_args ?slack_path ?branch ?pull_number ~head
-    ~repository ~owner () =
-  let repository =
-    {
-      Repository.owner;
-      name = repository;
-      src = fetch head;
-      pull_number;
-      branch;
-      slack_path;
-    }
-  in
-  let* commit =
-    match head with
-    | `Github api_commit -> Current.return (Github.Api.Commit.hash api_commit)
-    | `Local commit -> commit >>| Git.Commit.hash
-  in
-  pipeline ~conninfo ~run_args ~repository ~commit
+let pipeline ~conninfo ~run_args repository =
+  pipeline ~conninfo ~run_args ~repository
   |> slack_post ~repository
   |> Current.state
-  |> github_set_status ~repository head
+  |> github_set_status ~repository
 
-let github_pipeline ~conninfo ~run_args ?slack_path repo =
-  let pipeline = pipeline ~conninfo ~run_args in
+let github_repositories ?slack_path repo =
   let* refs =
     Current.component "Get PRs"
     |> let> api, repo = repo in
@@ -195,36 +171,25 @@ let github_pipeline ~conninfo ~run_args ?slack_path repo =
   let default_branch = Github.Api.default_ref refs in
   let default_branch_name = Util.get_branch_name default_branch in
   let ref_map = Github.Api.all_refs refs in
-  let* _, repo = repo in
-  let pipeline =
-    pipeline ?slack_path ~repository:repo.name ~owner:repo.owner
-  in
+  let+ _, repo = repo in
+  let repository = Repository.v ?slack_path ~name:repo.name ~owner:repo.owner in
   Github.Api.Ref_map.fold
-    (fun key head _ ->
-      let head = `Github head in
+    (fun key head lst ->
+      let commit = Github.Api.Commit.id head in
+      let repository = repository ~commit in
       match key with
-      | `Ref branch ->
-          if branch = default_branch then
-            pipeline ~head ~branch:default_branch_name ()
-          else Current.return ()
-      | `PR pull_number -> pipeline ~head ~pull_number ()
-      (* Skip all branches other than master, and check PRs *))
-    ref_map (Current.return ())
+      (* Skip all branches other than master, and check PRs *)
+      | `Ref branch when branch = default_branch ->
+          repository ~branch:default_branch_name () :: lst
+      | `Ref _ -> lst
+      | `PR pull_number -> repository ~pull_number () :: lst)
+    ref_map []
 
-let process_pipeline ~(docker_config : Docker_config.t) ~conninfo
-    ~(source : Source.t) () =
-  let run_args = Docker_config.run_args docker_config in
-  match source with
-  | Github { repo; slack_path; token } ->
-      let api =
-        token |> Util.read_fpath |> String.trim |> Current_github.Api.of_oauth
-      in
-      let repo = Current.return (api, repo) in
-      github_pipeline ~conninfo ~run_args ?slack_path repo
-  | Local path ->
+let repositories = function
+  | Source.Local path ->
       let local = Git.Local.v path in
-      let* head = Git.Local.head local in
-      let head_commit = `Local (Git.Local.head_commit local) in
+      let src = Git.Local.head_commit local in
+      let+ head = Git.Local.head local and+ commit = src >>| Git.Commit.id in
       let branch =
         match head with
         | `Commit _ -> None
@@ -236,16 +201,33 @@ let process_pipeline ~(docker_config : Docker_config.t) ~conninfo
                     log "Could not extract branch name from: %s" git_ref);
                 None)
       in
-      pipeline ~conninfo ~run_args
-        ?branch ~head:head_commit ~repository:"local" ~owner:"local" ()
+      [ Repository.v ?branch ~src ~commit ~name:"local" ~owner:"local" () ]
+  | Github { repo; slack_path; token } ->
+      let api =
+        token |> Util.read_fpath |> String.trim |> Current_github.Api.of_oauth
+      in
+      let repo = Current.return (api, repo) in
+      github_repositories ?slack_path repo
   | Github_app app ->
-      Github.App.installations app
-      |> Current.list_iter (module Github.Installation) @@ fun installation ->
-         let repos = Github.Installation.repositories installation in
-         repos
-         |> Current.list_iter ~collapse_key:"repo" (module Github.Api.Repo)
-            @@ fun repo ->
-                 github_pipeline ~conninfo ~run_args repo
+      let+ repos =
+        Github.App.installations app
+        |> Current.list_map (module Github.Installation) @@ fun installation ->
+           let repos = Github.Installation.repositories installation in
+           repos
+           |> Current.list_map ~collapse_key:"repo"
+                (module Github.Api.Repo)
+                github_repositories
+      in
+      List.concat (List.concat repos)
+
+let process_pipeline ~docker_config ~conninfo ~source () =
+  let run_args = Docker_config.run_args docker_config in
+  Current.list_iter
+    (module Repository)
+    (fun repository ->
+      let* repository = repository in
+      pipeline ~conninfo ~run_args repository)
+    (repositories source)
 
 let v ~current_config ~docker_config ~server:mode ~(source : Source.t) conninfo
     () =

--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -2,10 +2,30 @@ type t = {
   owner : string;
   name : string;
   src : Current_git.Commit.t Current.t;
+  commit : Current_git.Commit_id.t;
   pull_number : int option;
   branch : string option;
   slack_path : Fpath.t option;
+  github_head : Current_github.Api.Commit.t option;
 }
+
+let default_src ?src commit =
+  match src with
+  | None -> Current_git.fetch (Current.return commit)
+  | Some src -> src
+
+let v ~owner ~name ?src ~commit ?pull_number ?branch ?slack_path ?github_head ()
+    =
+  {
+    owner;
+    name;
+    commit;
+    pull_number;
+    branch;
+    slack_path;
+    github_head;
+    src = default_src ?src commit;
+  }
 
 let owner t = t.owner
 
@@ -13,17 +33,21 @@ let name t = t.name
 
 let src t = t.src
 
+let commit t = t.commit
+
+let commit_hash t = Current_git.Commit_id.hash t.commit
+
 let pull_number t = t.pull_number
 
 let branch t = t.branch
 
 let slack_path t = t.slack_path
 
+let github_head t = t.github_head
+
 let id t = (t.owner, t.name)
 
 let info t = t.owner ^ "/" ^ t.name
-
-let commit_hash t = Current.map Current_git.Commit.hash t.src
 
 let frontend_url = Sys.getenv "OCAML_BENCH_FRONTEND_URL"
 
@@ -35,3 +59,24 @@ let commit_status_url { owner; name; pull_number; _ } =
     | Some number -> "/" ^ owner ^ "/" ^ name ^ "/pull/" ^ string_of_int number
   in
   Uri.of_string (frontend_url ^ uri_end)
+
+let compare a b =
+  let cmp =
+    Stdlib.compare
+      (a.owner, a.name, a.branch, a.pull_number)
+      (b.owner, b.name, b.branch, b.pull_number)
+  in
+  match cmp with
+  | 0 -> Current_git.Commit_id.compare a.commit b.commit
+  | _ -> cmp
+
+let pp =
+  let open Fmt.Dump in
+  record
+    [
+      field "owner" owner Fmt.string;
+      field "name" name Fmt.string;
+      field "branch" branch Fmt.(option string);
+      field "pull_number" pull_number Fmt.(option int);
+      field "commit" commit_hash Fmt.string;
+    ]


### PR DESCRIPTION
This is a follow up on https://github.com/ocurrent/current-bench/pull/167 that completes the `Repository` refactoring (and justifies it :P )

The current code has a weird behavior for the github application. Each time a new PR is created, we go through each PR of the repo and create a new pipeline for each one:

https://github.com/ocurrent/current-bench/blob/a9bedb2ccc316d612e1493a24ac1f43a4705fe46/pipeline/lib/pipeline.ml#L206

Fortunately, most of those are already cached by ocurrent so they are fast (but still end up trying to write into the database).

The fix involves not spawning the pipelines from within `Ref_map.fold`: we have to go through ocurrent utilities (`list_iter`, `list_map`) that are able to detect the known PRs and will only spawn new pipelines for the previously unknown PRs.