### PR TITLE
Collapse pipeline nodes

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -223,6 +223,7 @@ let repositories = function
 let process_pipeline ~docker_config ~conninfo ~source () =
   let run_args = Docker_config.run_args docker_config in
   Current.list_iter
+    ~collapse_key:"pipeline"
     (module Repository)
     (fun repository ->
       let* repository = repository in


### PR DESCRIPTION
The graphviz automata is a bit large in production, so maybe we should collapse `[+]` the pipelines to reduce the noise :)