### PR TITLE
Alternative "keep alive" for bsb -make-world -w

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,11 @@ FROM node:lts AS dev
 ARG VITE_OCAML_BENCH_GRAPHQL_URL
 ARG VITE_OCAML_BENCH_PIPELINE_URL
 
+RUN apt-get update \
+    && apt-get install --no-install-recommends --assume-yes \
+        screen \
+    && rm -r /var/lib/apt/lists /var/cache/apt
+
 # set working directory
 WORKDIR /app
 

--- a/frontend/scripts/dev.sh
+++ b/frontend/scripts/dev.sh
@@ -9,10 +9,9 @@ echo "VITE_OCAML_BENCH_PIPELINE_URL=${VITE_OCAML_BENCH_PIPELINE_URL}" >> /app/.e
 echo "starting watch"
 rm -f .bsb.lock  # Remove any watcher locks, if the shutdown was not clean
 # NOTE: This is a workaround to avoid the watcher from exiting after compiling,
-# instead of watching.  The workaround of redirecting < /dev/zero to the
-# watcher is from the GH comment here:
-# https://github.com/rescript-lang/rescript-compiler/issues/2750#issuecomment-657402249
-yarn watch < /dev/zero &
+# instead of watching.
+screen -L /tmp/watch.log -dm yarn watch
+tail -F /tmp/watch.log &
 
 echo "starting serve"
 yarn serve


### PR DESCRIPTION
For reason that are beyond my understanding, the command `bsb -make-world -w < /dev/zero &` used for real-time development was eating my CPU alive... yet it works fine when run from a terminal, without the `< /dev/zero`.

But without the `< /dev/zero`, the `bsb` command exits and stops watching for changes, so we really need it. I tried to find another way of keeping the command alive via a detached `screen` session.

Am I the only one having the problem? Does the screen hack works for you? It seems a bit slower to print out the error messages from `bsb`, but the browser refresh looks fine.