### PR TITLE
Optimize release: do not rerun all benchmarks

### DIFF
--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -112,7 +112,7 @@ let dockerfile ~base ~dependencies ~opam_file =
   base_dockerfile ~base
   @@ install_static_dependencies
   @@ add_workdir
-  @@ run "opam exec -- opam pin ."
+  @@ run "opam exec -- opam pin -n ."
   @@ run "%s" (opam_install ~opam_file)
 
 let dockerfile ~pool ~run_args ~repository ~opam_file =

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -40,5 +40,7 @@ module Benchmark : sig
 
   module Db : sig
     val insert : Postgresql.connection -> t -> unit
+
+    val exists : Postgresql.connection -> Repository.t -> bool
   end
 end


### PR DESCRIPTION
When we deploy a new release and the pipeline has changed, ocurrent reruns everything since it could potentially produce a different result. This is not exactly desirable since it takes a very long time and most of our pipeline changes are not impactful on past PR.

This patch checks if we already have some benchmarks saved in sql for this repo/commit... and if so, it skips the rerun!

Also included is a small patch to `opam pin` since it may trigger some huge side effects (and it's a typical example of a pipeline change where we do not want to rerun everything since it's just a bugfix.)