### PR TITLE
Add current_bench_json.ml to share json validation between backend/frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+frontend/node_modules

--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -35,7 +35,8 @@ services:
     cpuset: "${OCAML_BENCH_PLATFORM_CPUSET}"
   frontend:
     build:
-      context: ../frontend
+      context: ..
+      dockerfile: ./frontend/Dockerfile
       target: dev
     environment:
       VITE_OCAML_BENCH_PIPELINE_URL: ${OCAML_BENCH_PIPELINE_URL?required}

--- a/environments/production.docker-compose.yaml
+++ b/environments/production.docker-compose.yaml
@@ -36,7 +36,8 @@ services:
     cpuset: "${OCAML_BENCH_PLATFORM_CPUSET}"
   frontend:
     build:
-      context: ../frontend
+      context: ..
+      dockerfile: ./frontend/Dockerfile
     environment:
       VITE_OCAML_BENCH_PIPELINE_URL: ${OCAML_BENCH_PIPELINE_URL?required}
       VITE_OCAML_BENCH_GRAPHQL_URL: ${OCAML_BENCH_GRAPHQL_URL?required}

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,14 +12,16 @@ RUN apt-get update \
 # set working directory
 WORKDIR /app
 
+COPY pipeline/lib/current_bench_json.ml /pipeline/lib/current_bench_json.ml
+
 # Build frontend code for production
 FROM dev AS builder
 
-COPY package.json yarn.lock /app/
+COPY frontend/package.json frontend/yarn.lock /app/
 RUN yarn install
 
 # add app
-COPY . /app/
+COPY frontend/. /app/
 
 RUN echo "VITE_OCAML_BENCH_GRAPHQL_URL=${VITE_OCAML_BENCH_GRAPHQL_URL}" > /app/.env
 RUN echo "VITE_OCAML_BENCH_PIPELINE_URL=${VITE_OCAML_BENCH_PIPELINE_URL}" >> /app/.env
@@ -30,7 +32,7 @@ RUN yarn bundle
 # build nginx image with static files built previously
 FROM nginx:stable-alpine
 
-COPY ./nginx.conf /etc/nginx/nginx.conf
+COPY frontend/nginx.conf /etc/nginx/nginx.conf
 
 ## Remove default nginx index page
 RUN rm -rf /usr/share/nginx/html/*

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -38,3 +38,13 @@ let formatSize = (value, units) => {
 
   (newValue, newUnit)
 }
+
+let format = (value, units) => {
+  switch value {
+    | Current_bench_json.Latest.Float(value) if isSize(units) =>
+        let (value, units) = formatSize(value, units)
+        (Current_bench_json.Latest.Float(value), units)
+    | _ =>
+        (value, units)
+  }
+}

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -37,66 +37,52 @@ let makeGetBenchmarksVariables = (
 module Benchmark = {
   let decodeRunAt = runAt => runAt->Js.Json.decodeString->Belt.Option.map(Js.Date.fromString)
 
-  let decodeMetrics = metrics =>
-    metrics
-    ->Belt.Option.getExn
-    ->Js.Json.decodeArray
-    ->Belt.Option.getExn
-    ->Belt.Array.keepMap(v => {
-        try {
-          Some(v->Js.Json.decodeObject->Belt.Option.getExn->BenchmarkTest.decodeMetric)
-        } catch {
-          | _ => None
-        }
-      })
+  let yojson_of_result = (result : BenchmarkMetrics.t) => {
+    let metrics = DataHelpers.yojson_of_json(result.metrics->Belt.Option.getExn)
+    #Assoc(list{("version", #Int(result.version)),
+                ("results", #List(list{#Assoc(list{("name", #String(result.test_name)),
+                                                  ("metrics", metrics)})}))})
+  }
 
-  let migrateVersions = (benchmarks: array<BenchmarkMetrics.t>): array<BenchmarkMetrics.t> => {
-    // Convert metrics from an object to an array of objects and add units
-    let version1To2 = (benchmark: BenchmarkMetrics.t): BenchmarkMetrics.t => {
-      let metricsToArray = metrics =>
-        metrics
-        ->Belt.Option.getExn
-        ->Js.Json.decodeObject
-        ->Belt.Option.getExn
-        ->Js.Dict.entries
-        ->Belt.Array.map(((key, value)) => {
-            Js.Json.object_(Js.Dict.fromList(list{
-              ("name", Js.Json.string(key)),
-              ("value", value),
-              ("units", Js.Json.string("")),
-            }))
-          })
-        ->Js.Json.array
-        ->Some
+  let decode = (result : BenchmarkMetrics.t) => {
+    let metrics = yojson_of_result(result)
+    let metrics = Current_bench_json.of_json(metrics)
+    let run_at = result.run_at->decodeRunAt->Belt.Option.getExn
+    (result.commit, run_at, metrics)
+  }
 
-      switch benchmark.version {
-      | 1 => {...benchmark, version: 2, metrics: metricsToArray(benchmark.metrics)}
-      | _ => benchmark
-      }
+  let tryDecode = (result) => {
+    try {
+      Some(decode(result))
+    } catch {
+      | _ => None
     }
-    // New functions to migrate from previous latest version to next version can be added here. 
-    // For instance, define a function version2To3 and append `->Belt.Array.map(version2To3)` to the expression below
-    benchmarks->Belt.Array.map(version1To2)
+  }
+
+  let toLineGraph = (value : Current_bench_json.Latest.value) => {
+    switch value {
+      | Float(x) => LineGraph.DataRow.single(x)
+      | Floats(xs) => LineGraph.DataRow.many(Array.of_list(xs))
+    }
   }
 
   let makeBenchmarkData = (benchmarks: array<BenchmarkMetrics.t>) => {
     benchmarks
-    ->migrateVersions
-    ->Belt.Array.reduce(BenchmarkData.empty, (acc, item) => {
-      item.metrics
-      ->decodeMetrics
-      ->Belt.Array.reduce(acc, (acc, metric: LineGraph.DataRow.metric) => {
-        BenchmarkData.add(
-          acc,
-          ~testName=item.test_name,
-          ~testIndex=item.test_index,
-          ~metricName=metric.name,
-          ~runAt=item.run_at->decodeRunAt->Belt.Option.getExn,
-          ~commit=item.commit,
-          ~value=metric.value,
-          ~units=metric.units,
-        )
-      })
+    ->Belt.Array.keepMap(tryDecode)
+    ->Belt.Array.reduce(BenchmarkData.empty, (acc, (commit, run_at, item)) => {
+        ->List.fold_left((acc, (result : Current_bench_json.Latest.result) ) => {
+            List.fold_left((acc, (metric : Current_bench_json.Latest.metric)) => {
+              BenchmarkData.add(
+                acc,
+                ~testName=result.test_name,
+                ~metricName=metric.name,
+                ~runAt=run_at,
+                ~commit=commit,
+                ~value=toLineGraph(metric.value),
+                ~units=metric.units,
+              )
+            }, acc, result.metrics)
+        }, acc, item.results)
     })
   }
   @react.component

--- a/frontend/src/DataHelpers.res
+++ b/frontend/src/DataHelpers.res
@@ -1,1 +1,16 @@
 let trimCommit = commit => String.length(commit) > 7 ? String.sub(commit, 0, 7) : commit
+
+let rec yojson_of_json = (json : Js.Json.t) : Current_bench_json.Json.t => {
+  switch Js.Json.classify(json) {
+    | JSONFalse => #Bool(false)
+    | JSONTrue => #Bool(true)
+    | JSONNull => #Null
+    | JSONString(s) => #String(s)
+    | JSONNumber(x) => #Float(x)
+    | JSONArray(arr) =>
+        #List(List.map(yojson_of_json, arr->Array.to_list))
+    | JSONObject(dict) =>
+        #Assoc(List.map(((key, val)) => { (key, yojson_of_json(val)) },
+                        dict->Js.Dict.entries->Array.to_list))
+  }
+}

--- a/frontend/src/current_bench_json.ml
+++ b/frontend/src/current_bench_json.ml
@@ -1,0 +1,1 @@
+../../pipeline/lib/current_bench_json.ml

--- a/pipeline/lib/current_bench_json.ml
+++ b/pipeline/lib/current_bench_json.ml
@@ -1,0 +1,193 @@
+(* Warning: This file is used in the pipeline AND the frontend.
+ * It must remain compatible with Rescript ~= OCaml 4.06 with a few missing stdlib modules
+ * and must have no external dependency.
+ *)
+
+module Json = struct
+  type t =
+    (* Yojson.Safe.t = *)
+    [ `Null
+    | `Bool of bool
+    | `Int of int
+    | `Intlit of string
+    | `Float of float
+    | `String of string
+    | `Assoc of (string * t) list
+    | `List of t list
+    | `Tuple of t list
+    | `Variant of string * t option ]
+
+  let member field = function
+    | `Assoc obj -> (
+        match List.assoc_opt field obj with None -> `Null | Some x -> x)
+    | _ -> `Null
+
+  let to_string_option = function `String s -> Some s | _ -> None
+
+  let to_int_option = function `Int s -> Some s | _ -> None
+
+  let to_list = function `List xs -> xs | _ -> invalid_arg "Json: not a list"
+
+  let to_assoc = function
+    | `Assoc xs -> xs
+    | _ -> invalid_arg "Json: not a list"
+
+  let get = member
+
+  let to_string = function
+    | `String s -> s
+    | `Null -> invalid_arg "Json: not a string but a null"
+    | `Bool _ -> invalid_arg "Json: not a string but a bool"
+    | `Int _ -> invalid_arg "Json: not a string int"
+    | `Intlit _ -> invalid_arg "Json: not a string intlit"
+    | `Float _ -> invalid_arg "Json: not a string float"
+    | `Assoc _ -> invalid_arg "Json: not a string assoc"
+    | `List _ -> invalid_arg "Json: not a string list"
+    | `Tuple _ -> invalid_arg "Json: not a string tuple"
+    | `Variant _ -> invalid_arg "Json: not a string variant"
+    | _ -> invalid_arg "Json: not a string"
+
+  let to_float = function
+    | `Float x -> x
+    | `Int x -> float_of_int x
+    | _ -> invalid_arg "Json: not a float"
+end
+
+let default d = function None -> d | Some x -> x
+
+let rec list_find_map f = function
+  | [] -> raise Not_found
+  | x :: xs -> ( match f x with Some y -> y | None -> list_find_map f xs)
+
+let scanf fmt fn ~str = try Some (Scanf.sscanf str fmt fn) with _ -> None
+
+module V2 = struct
+  let version = 2
+
+  type value = Float of float | Floats of float list
+
+  type metric = { name : string; value : value; units : string }
+
+  type result = { test_name : string; metrics : metric list }
+
+  type t = { benchmark_name : string option; results : result list }
+
+  let value_of_json = function
+    | `Float x -> (x, "")
+    | `Int x -> (float_of_int x, "")
+    | `Intlit s -> (float_of_string s, "")
+    | `String str ->
+        list_find_map
+          (fun f -> f ~str)
+          [
+            scanf "%fmin%fs" (fun min sec -> ((min *. 60.) +. sec, "s"));
+            scanf "%f%s" (fun x u -> (x, u));
+          ]
+    | _ -> failwith "V2: not a value"
+
+  let value_of_json = function
+    | `List vs ->
+        let vs, units = List.split @@ List.map value_of_json vs in
+        (Floats vs, units)
+    | v ->
+        let v, unit = value_of_json v in
+        (Float v, [ unit ])
+
+  let json_of_value = function
+    | Float f -> `Float f
+    | Floats fs -> `List (List.map (fun f -> `Float f) fs)
+
+  let rec find_units = function
+    | [] -> ""
+    | x :: _ when x <> "" -> x
+    | _ :: xs -> find_units xs
+
+  let value_of_json ?(units = "") t =
+    let value, units_list = value_of_json t in
+    let units = find_units (units :: units_list) in
+    (value, units)
+
+  let metric_of_json t =
+    let units = Json.get "units" t |> Json.to_string_option |> default "" in
+    let value, units = value_of_json ~units (Json.get "value" t) in
+    { name = Json.get "name" t |> Json.to_string; value; units }
+
+  let json_of_metric m =
+    `Assoc
+      [
+        ("name", `String m.name);
+        ("value", json_of_value m.value);
+        ("units", `String m.units);
+      ]
+
+  let json_of_metrics metrics = `List (List.map json_of_metric metrics)
+
+  let json_of_result m =
+    `Assoc
+      [ ("name", `String m.test_name); ("metrics", json_of_metrics m.metrics) ]
+
+  let result_of_json t =
+    {
+      test_name = Json.get "name" t |> Json.to_string;
+      metrics = Json.get "metrics" t |> Json.to_list |> List.map metric_of_json;
+    }
+
+  let of_json t =
+    {
+      benchmark_name = Json.get "name" t |> Json.to_string_option;
+      results = Json.get "results" t |> Json.to_list |> List.map result_of_json;
+    }
+end
+
+module V1 = struct
+  let version = 1
+
+  type value = V2.value
+
+  type metric = V2.metric
+
+  type result = V2.result
+
+  type t = V2.t
+
+  let metric_of_json (name, value) =
+    let value, units = V2.value_of_json value in
+    { V2.name; value; units }
+
+  let result_of_json t =
+    {
+      V2.test_name = Json.get "name" t |> Json.to_string;
+      metrics = Json.get "metrics" t |> Json.to_assoc |> List.map metric_of_json;
+    }
+
+  let of_json t =
+    {
+      V2.benchmark_name = Json.get "name" t |> Json.to_string_option;
+      results = Json.get "results" t |> Json.to_list |> List.map result_of_json;
+    }
+
+  let to_v2 t = t
+end
+
+module Latest = V2
+
+let of_json json =
+  match Json.get "version" json with
+  | `Int 2 -> V2.of_json json
+  | _ -> V1.to_v2 @@ V1.of_json json
+
+let validate t =
+  let open V2 in
+  let tbl = Hashtbl.create 16 in
+  List.iter
+    (fun result ->
+      let key = result.benchmark_name in
+      match Hashtbl.find_opt tbl key with
+      | Some _ ->
+          failwith
+            "This benchmark name already exists, please create a unique name"
+      | None ->
+          Hashtbl.add tbl key
+            (Latest.version, List.map json_of_result result.results))
+    t;
+  tbl

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -9,32 +9,8 @@ module Benchmark = Models.Benchmark
 
 let ( >>| ) x f = Current.map f x
 
-let get_benchmark_name json =
-  json |> Yojson.Safe.Util.(member "name") |> Yojson.Safe.Util.to_string_option
-
-let get_benchmark_version json =
-  json |> Yojson.Safe.Util.(member "version") |> Yojson.Safe.Util.to_int_option
-  |> fun version -> match version with None -> 1 | Some i -> i
-
-let get_result_list json =
-  json |> Yojson.Safe.Util.(member "results") |> Yojson.Safe.Util.to_list
-
 let validate_json json_list =
-  let tbl = Hashtbl.create 1000 in
-  List.iter
-    (fun json ->
-      let benchmark_name = get_benchmark_name json in
-      let version = get_benchmark_version json in
-      match Hashtbl.find_opt tbl benchmark_name with
-      | Some _ ->
-          raise
-          @@ Failure
-               "This benchmark name already exists, please create a unique name"
-      | None ->
-          let results = get_result_list json in
-          Hashtbl.add tbl benchmark_name (version, results))
-    json_list;
-  tbl
+  Current_bench_json.(validate (List.map of_json json_list))
 
 module Source = struct
   type github = {


### PR DESCRIPTION
Currently the json format is defined partially in the pipeline (which doesn't care about validating the metrics, just the general shape) and the frontend (which only cares about the metrics). We've had situations where the pipeline would succeed even though the metrics were unreadable by the frontend.

I tried to setup a way for the backend and frontend to agree on what the entire json should be, such that the pipeline can indicate a problem if the user submits bad metrics, and that both can stay uptodate with the latest schema. The result is in `pipeline/lib/current_bench_json.ml` and by the magic of symbolic link, it's also available in the Rescript frontend (I had to fight both buildsystem and docker, so I hope it works now!)

There are some strong limitations in this shared file. It can not depend on any other file and Rescript only understands OCaml 4.06 with a limited stdlib (no regex?!.. and no Yojson or other dependencies)

Perhaps it can also be useful if at some point we expose a user library to help projects produce the latest version of the json.