### PR TITLE
Simplify production deployments to be a single command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,14 @@ start-production:
 		--detach \
 		--build
 
+.PHONY: build-production
+build-production:
+	docker-compose \
+		--project-name="current-bench" \
+		--file=./environments/production.docker-compose.yaml \
+		--env-file=./environments/production.env \
+		build
+
 .PHONY: stop-production
 stop-production:
 	docker-compose \

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ stop-production:
 ./local-test-repo/.git:
 	cd ./local-test-repo/ && git init && git add . && git commit -m "Initial commit."
 
+.PHONY: run-migrations
+run-migrations:
+	docker exec -it current-bench_pipeline_1 omigrate up \
+		--verbose --source=/app/db/migrations \
+		--database=postgresql://docker:docker@db:5432/docker
+
 .PHONY: start-development
 start-development: ./local-test-repo/.git
 	docker-compose \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ stop-production:
 		--env-file=./environments/production.env \
 		down
 
+.PHONY: redeploy-production
+redeploy-production: \
+	build-production \
+	run-migrations \
+	stop-production \
+	start-production
+
 # Make sure the fake testing repo is initialised.
 ./local-test-repo/.git:
 	cd ./local-test-repo/ && git init && git add . && git commit -m "Initial commit."


### PR DESCRIPTION
This PR adds a make target to redeploy a production deployment. 

1. It builds the containers required, before stopping the currently running instance, to reduce the down-time of the service. 

2. It adds a commit to use `omigrate` to run the migrations instead of manually running the migrations on the Postgres DB.  The production DB may need to be updated to mark the existing migrations as already run. I'm not sure why we used the manual approach so far, and this seems better, unless I'm missing something. I don't have access to the production servers, right now, to check what needs to be done there to make this PR usable. 