### PR TITLE
Hide benchmarks sidebar menu when there's a single benchmark

### DIFF
--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -102,10 +102,14 @@ module SidebarMenu = {
     | Fetching => Rx.text("Loading...")
     | Data({benchmarksMenuData, pullsMenuData})
     | PartialData({benchmarksMenuData, pullsMenuData}, _) => <>
-        <Column>
-          <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Benchmarks" </Text>
-          <BenchmarksMenu repoId benchmarksMenuData ?selectedPull ?selectedBenchmarkName />
-        </Column>
+        {switch Js.Array.length(benchmarksMenuData) > 1 {
+        | true =>
+          <Column>
+            <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Benchmarks" </Text>
+            <BenchmarksMenu repoId benchmarksMenuData ?selectedPull ?selectedBenchmarkName />
+          </Column>
+        | false => Rx.null
+        }}
         <Column>
           <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Pull Requests" </Text>
           <PullsMenu repoId pullsMenuData ?selectedPull ?selectedBenchmarkName />


### PR DESCRIPTION
The JSON schema supports adding multiple benchmarks, but all of our users
currently have only a single benchmark. The sidebar menu displays this
benchmark's results under the name "Main" which users sometimes confuse to mean
the "main" git branch.

This commit hides the Benchmarks sidebar menu when there's a single benchmark
under which all the tests are present. When there are multiple benchmarks, the
benchmarks MUST to be named and this will make the side bar menu less
confusing.

Closes #136