### PR TITLE
Pin packages as .dev, unless they specify a version

### DIFF
--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -61,8 +61,13 @@ let base_dockerfile ~base =
 
 let add_workdir =
   let open Dockerfile in
-  copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir" ()
-  @@ workdir "bench-dir"
+  (* If the package's directory name doesn't contain a dot then opam will default to
+     using the last known version, which is usually wrong. In particular, if a multi-project
+     repostory adds a new package with a constraint "{ =version }" on an existing one,
+     this will fail because opam will pin the new package as "dev" but the old one with
+     the version of its last release, which is why we add .dev to the directory name. *)
+  copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir.dev" ()
+  @@ workdir "bench-dir.dev"
   @@ add ~src:[ "--chown=opam ." ] ~dst:"." ()
 
 let minimal_dockerfile ~base =

--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -63,8 +63,8 @@ let add_workdir =
   let open Dockerfile in
   (* If the package's directory name doesn't contain a dot then opam will default to
      using the last known version, which is usually wrong. In particular, if a multi-project
-     repostory adds a new package with a constraint "{ =version }" on an existing one,
-     this will fail because opam will pin the new package as "dev" but the old one with
+     repository adds a new package with a constraint "{ =version }" on an existing one,
+     this will fail because opam will pin the new package as "~dev" but the old one with
      the version of its last release, which is why we add .dev to the directory name. *)
   copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir.dev" ()
   @@ workdir "bench-dir.dev"

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -87,7 +87,7 @@ module Docker_config = struct
       "--security-opt";
       "seccomp=./aslr_seccomp.json";
       "--mount";
-      "type=volume,src=current-bench-data,dst=/home/opam/bench-dir/current-bench-data";
+      "type=volume,src=current-bench-data,dst=/home/opam/bench-dir.dev/current-bench-data";
     ]
     @ tmpfs t
     @ cpuset_cpus t


### PR DESCRIPTION
When a multi-repository project adds a new package with a constraint `{= "version"}` on an existing one, this will
fail because opam will pin the new package as dev but the old package as a version of it's last release. Making the
bench-dir folder as a `dev` folder ensures that it's also picked up as a dev version.