### PR TITLE
Pin local opam packages without confirmation for static dependencies

### DIFF
--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -69,6 +69,7 @@ let add_workdir =
   copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir.dev" ()
   @@ workdir "bench-dir.dev"
   @@ add ~src:[ "--chown=opam ." ] ~dst:"." ()
+  @@ run "opam exec -- opam pin -y -n ."
 
 let minimal_dockerfile ~base =
   let open Dockerfile in
@@ -117,7 +118,6 @@ let dockerfile ~base ~dependencies ~opam_file =
   base_dockerfile ~base
   @@ install_static_dependencies
   @@ add_workdir
-  @@ run "opam exec -- opam pin -n ."
   @@ run "%s" (opam_install ~opam_file)
 
 let dockerfile ~pool ~run_args ~repository ~opam_file =


### PR DESCRIPTION
The `opam pin -n .` command was introduced to fix an issue with irmin packages. I'm not entirely sure how it will interact with the computation of static dependencies, but it would help if the pins were also available at this stage. (also added the `-y` to avoid confirmation)