### PR TITLE
Pin to dev for opam, and undo previous dev changes

### DIFF
--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -58,15 +58,10 @@ let base_dockerfile ~base =
         liblmdb-dev m4 pkg-config gnuplot-x11 libgmp-dev libssl-dev \
         libpcre3-dev && opam remote add origin https://opam.ocaml.org && opam \
         update"
-  @@ run "mv /usr/bin/opam-2.1 /usr/bin/opam"
+  @@ run "sudo mv /usr/bin/opam-2.1 /usr/bin/opam"
 
 let add_workdir =
   let open Dockerfile in
-  (* If the package's directory name doesn't contain a dot then opam will default to
-     using the last known version, which is usually wrong. In particular, if a multi-project
-     repository adds a new package with a constraint "{ =version }" on an existing one,
-     this will fail because opam will pin the new package as "~dev" but the old one with
-     the version of its last release, which is why we add .dev to the directory name. *)
   copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir" ()
   @@ workdir "bench-dir"
   @@ add ~src:[ "--chown=opam ." ] ~dst:"." ()

--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -67,8 +67,8 @@ let add_workdir =
      repository adds a new package with a constraint "{ =version }" on an existing one,
      this will fail because opam will pin the new package as "~dev" but the old one with
      the version of its last release, which is why we add .dev to the directory name. *)
-  copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir.dev" ()
-  @@ workdir "bench-dir.dev"
+  copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir" ()
+  @@ workdir "bench-dir"
   @@ add ~src:[ "--chown=opam ." ] ~dst:"." ()
   @@ run "opam exec -- opam pin -y -n --with-version=dev ."
 

--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -58,6 +58,7 @@ let base_dockerfile ~base =
         liblmdb-dev m4 pkg-config gnuplot-x11 libgmp-dev libssl-dev \
         libpcre3-dev && opam remote add origin https://opam.ocaml.org && opam \
         update"
+  @@ run "mv /usr/bin/opam-2.1 /usr/bin/opam"
 
 let add_workdir =
   let open Dockerfile in

--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -69,7 +69,7 @@ let add_workdir =
   copy ~src:[ "--chown=opam:opam ." ] ~dst:"bench-dir.dev" ()
   @@ workdir "bench-dir.dev"
   @@ add ~src:[ "--chown=opam ." ] ~dst:"." ()
-  @@ run "opam exec -- opam pin -y -n ."
+  @@ run "opam exec -- opam pin -y -n --with-version=dev ."
 
 let minimal_dockerfile ~base =
   let open Dockerfile in

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -87,7 +87,7 @@ module Docker_config = struct
       "--security-opt";
       "seccomp=./aslr_seccomp.json";
       "--mount";
-      "type=volume,src=current-bench-data,dst=/home/opam/bench-dir.dev/current-bench-data";
+      "type=volume,src=current-bench-data,dst=/home/opam/bench-dir/current-bench-data";
     ]
     @ tmpfs t
     @ cpuset_cpus t


### PR DESCRIPTION
`ocaml/opam` doesn't come with 2.1, so need to change that. Also, just renaming the directory to `.dev` doesn't work 🤡, need to actually look at file structure, append `.dev` to file and then run opam pin. Sidestepping that by using `--with-version` (available in opam 2.1).