### PR TITLE
Add make target to clean local test repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ redeploy-production: \
 ./local-test-repo/.git:
 	cd ./local-test-repo/ && git init && git add . && git commit -m "Initial commit."
 
+# Clean the fake testing repo
+.PHONY: clean-local-test-repo
+clean-local-test-repo:
+	cd ./local-test-repo/ && rm -rf .git/
+
 .PHONY: run-migrations
 run-migrations:
 	docker exec -it current-bench_pipeline_1 omigrate up \


### PR DESCRIPTION
It is useful to clean up the experiments done in local test repo, after
finishing working on a particular feature/bug. It is potentially more
error-prone to do it manually and accidentally deleting the `.git` directory of
the `current-bench` repository. Having a make target for this would make it a
safer action to perform.