### PR TITLE
Skip old commits

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -181,6 +181,7 @@ let github_repositories ?slack_path repo =
        Github.Api.refs api repo
   in
   let default_branch = Github.Api.default_ref refs in
+  let stale_timestamp = Util.stale_timestamp () in
   let default_branch_name = Util.get_branch_name default_branch in
   let ref_map = Github.Api.all_refs refs in
   let+ _, repo = repo in
@@ -189,12 +190,15 @@ let github_repositories ?slack_path repo =
     (fun key head lst ->
       let commit = Github.Api.Commit.id head in
       let repository = repository ~commit ~github_head:head in
-      match key with
-      (* Skip all branches other than master, and check PRs *)
-      | `Ref branch when branch = default_branch ->
-          repository ~branch:default_branch_name () :: lst
-      | `Ref _ -> lst
-      | `PR pull_number -> repository ~pull_number () :: lst)
+      (* If commit is more than two weeks old, then skip it.*)
+      if Github.Api.Commit.committed_date head > stale_timestamp then
+        match key with
+        (* Skip all branches other than the default branch, and check PRs *)
+        | `Ref branch when branch = default_branch ->
+            repository ~branch:default_branch_name () :: lst
+        | `Ref _ -> lst
+        | `PR pull_number -> repository ~pull_number () :: lst
+      else lst)
     ref_map []
 
 let repositories = function

--- a/pipeline/lib/util.ml
+++ b/pipeline/lib/util.ml
@@ -6,3 +6,14 @@ let get_branch_name branch =
   let prefix = "refs/heads/" in
   let len_prefix = String.length prefix in
   String.sub branch len_prefix (String.length branch - len_prefix)
+
+let stale_timestamp () =
+  let two_weeks_in_seconds = 1209600. in
+  let curr_gmt = Unix.gmtime (Unix.time () -. two_weeks_in_seconds) in
+  let year = curr_gmt.tm_year + 1900 in
+  let month = curr_gmt.tm_mon + 1 in
+  let day = curr_gmt.tm_mday in
+  let hour = curr_gmt.tm_hour in
+  let min = curr_gmt.tm_min in
+  let sec = curr_gmt.tm_sec in
+  Format.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ" year month day hour min sec

--- a/pipeline/lib/util.mli
+++ b/pipeline/lib/util.mli
@@ -1,3 +1,5 @@
 val read_fpath : Fpath.t -> string
 
 val get_branch_name : string -> string
+
+val stale_timestamp : unit -> string


### PR DESCRIPTION
We currently re-run on all open PRs when we re-deploy CB. This means that sometimes we take more than a day to re-run all benchmarks (a lot of the older ones will fail because they don't have the changes to run the benchmarks). This patch skips all commits that are more than two weeks old.

I don't have a very strong opinion about the two weeks, we can also make it four weeks. :)