### PR TITLE
Hot reload pipeline on code changes for quick development

### DIFF
--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -61,6 +61,7 @@ services:
   pipeline:
     build:
       context: ../pipeline
+      dockerfile: ./Dockerfile.dev
       args:
         TARGET_ARCH: ${OCAML_BENCH_TARGET_ARCH?required}
     volumes:
@@ -69,9 +70,11 @@ services:
       - ../local-test-repo:/app/local-test-repo
       - /var/run/docker.sock:/var/run/docker.sock
       - ../pipeline/db/migrations:/app/db/migrations
+      - ../pipeline:/mnt/project
     ports: ["${OCAML_BENCH_PIPELINE_PORT?required}:${OCAML_BENCH_PIPELINE_PORT?required}"]
     command:
-      - "current-bench-pipeline"
+      - "/mnt/project/reload.sh"
+      - "/app/bin/current-bench-pipeline"
       - "local"
       - "/app/local-test-repo"
       - "--verbose"

--- a/pipeline/Dockerfile.dev
+++ b/pipeline/Dockerfile.dev
@@ -1,0 +1,63 @@
+FROM ocaml/opam:debian-ocaml-4.13 AS build
+
+RUN sudo apt-get update && \
+    sudo apt-get install -qq -yy \
+    libffi-dev \
+    m4 \
+    pkg-config \
+    libssl-dev \
+    libgmp-dev \
+    libpq-dev \
+    graphviz \
+    capnproto \
+    libsqlite3-dev \
+    libcapnp-dev \
+    libev-dev
+
+WORKDIR /mnt/project
+
+# Build dependencies.
+COPY --chown=opam:opam pipeline.opam pipeline.opam
+RUN opam install -y --deps-only -t .
+
+USER root
+
+ARG TARGET_ARCH=amd64
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --assume-yes \
+        netbase \
+        ca-certificates \
+        apt-transport-https \
+        curl \
+        netcat \
+        postgresql-client \
+        gnupg \
+        lsb-release \
+        git \
+        libpq-dev \
+        libsqlite3-dev \
+        libev-dev \
+        inotify-tools \
+        procps \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=${TARGET_ARCH} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install docker-ce-cli graphviz --assume-yes \
+    && rm -r /var/lib/apt/lists /var/cache/apt
+
+COPY --chown=opam . .
+
+# Build the project.
+RUN opam exec -- dune build --profile=release bin/main.exe
+
+WORKDIR /app
+
+RUN mkdir bin
+ENV PATH="/app/bin:${PATH}"
+
+COPY ./aslr_seccomp.json /app/aslr_seccomp.json
+COPY ./db/migrations /app/db/migrations
+RUN cp /home/opam/.opam/4.13/bin/omigrate /app/bin/omigrate
+RUN cp /mnt/project/_build/default/bin/main.exe /app/bin/current-bench-pipeline

--- a/pipeline/reload.sh
+++ b/pipeline/reload.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+COMMAND="${*@Q}"
+
+function run {
+  cd /app
+  sh -c "$COMMAND" &
+}
+
+run
+
+while :
+do
+  cd /mnt/project
+
+  inotifywait -q -q -e CLOSE_WRITE \
+    lib/dune lib/*.ml lib/*.mli \
+    bin/dune bin/*.ml bin/*.mli
+
+  dune build bin/main.exe \
+  && (pkill -f '^/app/bin/current-bench-pipeline' || echo 'Not running?') \
+  && sleep 0.1 \
+  && cp _build/default/bin/main.exe /app/bin/current-bench-pipeline \
+  && run
+done


### PR DESCRIPTION
When developing, the pipeline restart can be very slow! The `reload.sh` scripts watches for changes and re-run the pipeline on code changes (without rebuilding a fresh new docker every time).

I'm not sure if we can get rid of `Dockerfile.dev`: it's very similar to the production one, but must keep the opam environment. Do you know a better way?