### PR TITLE
Extract json from mixed output

### DIFF
--- a/current-bench.opam
+++ b/current-bench.opam
@@ -29,6 +29,7 @@ depends: [
   "postgresql"
   "rresult"
   "omigrate"
+  "pcre"
 ]
 
 pin-depends: [

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -12,7 +12,8 @@ RUN sudo apt-get update && \
     capnproto \
     libsqlite3-dev \
     libcapnp-dev \
-    libev-dev
+    libev-dev \
+    libpcre3-dev
 
 WORKDIR /mnt/project
 

--- a/pipeline/lib/dune
+++ b/pipeline/lib/dune
@@ -3,4 +3,4 @@
  (public_name pipeline)
  (libraries current current.fs current_docker current_git current_github
    current_slack current_web dockerfile fmt.tty logs logs.fmt prometheus
-   rresult uri curly postgresql yojson str))
+   rresult uri curly postgresql yojson str pcre))

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -29,6 +29,7 @@ depends: [
   "postgresql"
   "rresult"
   "omigrate"
+  "pcre"
 ]
 pin-depends: [
   [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]


### PR DESCRIPTION
This PR is a rebase of the work of @shubhamkumar13 which allow to extract the json metrics when the `make bench` output also contains other things. This will be especially important with ocluster workers, where stderr and stdout will be interleaved (at least for the first version).