### PR TITLE
Make json in the local test repo to be valid

### DIFF
--- a/local-test-repo/Makefile
+++ b/local-test-repo/Makefile
@@ -1,7 +1,6 @@
 define BENCH_DATA_1
 {
-  "config": {
-  },
+  "config": null,
   "version": 2,
   "results": [
     {
@@ -50,7 +49,8 @@ endef
 
 define BENCH_DATA_2
 {
-  "config": {  },
+  "config": null,
+  "version": 2,
   "results": [
     {
       "name": "bench_2_test_1",


### PR DESCRIPTION
5b1b68974eb38a72be282a7ac7b8c43458532b86 added validation on the backend for
the JSON schema consumed for the benchmark metrics. The JSON in the
local-test-repo Makefile doesn't validate correctly, and this commit fixes it.
