### PR TITLE
Fix broken frontend watcher screen command

### DIFF
--- a/frontend/scripts/dev.sh
+++ b/frontend/scripts/dev.sh
@@ -10,7 +10,7 @@ echo "starting watch"
 rm -f .bsb.lock  # Remove any watcher locks, if the shutdown was not clean
 # NOTE: This is a workaround to avoid the watcher from exiting after compiling,
 # instead of watching.
-screen -L /tmp/watch.log -dm yarn watch
+screen -Logfile /tmp/watch.log -dm yarn watch
 tail -F /tmp/watch.log &
 
 echo "starting serve"


### PR DESCRIPTION
The screen command that runs the `yarn watch` command incorrectly used the `-L`
argument for the log file, instead of the `-Logfile` argument. Not sure how
this has been working so far. Possibly, `node:lts` image changed the base
image, or something which changed the screen version, but I couldn't confirm
this hypothesis.