### PR TITLE
Add PR titles to UI

### DIFF
--- a/frontend/graphql_schema.json
+++ b/frontend/graphql_schema.json
@@ -1,314 +1,247 @@
 {
   "__schema": {
-    "directives": [
-      {
-        "args": [
-          {
-            "name": "if",
-            "defaultValue": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "description": null
-          }
-        ],
-        "name": "include",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
-        "description": null
-      },
-      {
-        "args": [
-          {
-            "name": "if",
-            "defaultValue": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "description": null
-          }
-        ],
-        "name": "skip",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
-        "description": null
-      }
-    ],
     "queryType": {
-      "name": "query_root"
+      "name": "query_root",
+      "__typename": "__Type"
+    },
+    "mutationType": {
+      "name": "mutation_root",
+      "__typename": "__Type"
     },
     "subscriptionType": {
-      "name": "subscription_root"
+      "name": "subscription_root",
+      "__typename": "__Type"
     },
     "types": [
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "Boolean",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": [
-          {
-            "name": "_eq",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_gt",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_gte",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_in",
-            "defaultValue": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            "description": null
-          },
-          {
-            "name": "_is_null",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_lt",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_lte",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_neq",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_nin",
-            "defaultValue": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            "description": null
-          }
-        ],
         "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "Boolean_comparison_exp",
-        "enumValues": null,
         "description": "expression to compare columns of type Boolean. All fields are combined with logical 'AND'.",
-        "fields": null
-      },
-      {
-        "inputFields": null,
-        "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "Float",
-        "enumValues": null,
-        "description": null,
-        "fields": null
-      },
-      {
-        "inputFields": null,
-        "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "ID",
-        "enumValues": null,
-        "description": null,
-        "fields": null
-      },
-      {
-        "inputFields": null,
-        "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "Int",
-        "enumValues": null,
-        "description": null,
-        "fields": null
-      },
-      {
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_gt",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_gte",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "_in",
-            "defaultValue": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            "description": null
-          },
-          {
-            "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "name": "Boolean",
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "name": "Boolean",
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "name": "Boolean",
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
             "defaultValue": null,
+            "__typename": "__InputValue"
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "SCALAR",
+        "name": "ID",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "Int_comparison_exp",
+        "description": "expression to compare columns of type Int. All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_in",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -318,76 +251,160 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "Int_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type Int. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "String",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "String_comparison_exp",
+        "description": "expression to compare columns of type String. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_ilike",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -397,75 +414,91 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_like",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nilike",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -475,65 +508,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nlike",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nsimilar",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_similar",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "String_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type String. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Directive",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "args",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -546,30 +581,37 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__InputValue",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "locations",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -582,231 +624,270 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "__DirectiveLocation",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          }
-        ]
-      },
-      {
-        "inputFields": null,
-        "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "__DirectiveLocation",
-        "enumValues": [
-          {
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "ARGUMENT_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "ENUM",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "ENUM_VALUE",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FIELD",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FIELD_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FRAGMENT_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FRAGMENT_SPREAD",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INLINE_FRAGMENT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INPUT_FIELD_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INPUT_OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INTERFACE",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "MUTATION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "QUERY",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SCALAR",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SCHEMA",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SUBSCRIPTION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "UNION",
-            "description": null
+            "__typename": "__Field"
           }
         ],
-        "description": null,
-        "fields": null
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "ENUM",
+        "name": "__DirectiveLocation",
+        "description": null,
+        "fields": null,
         "inputFields": null,
-        "kind": "OBJECT",
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ARGUMENT_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "ENUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "ENUM_VALUE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FIELD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FIELD_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FRAGMENT_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FRAGMENT_SPREAD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INLINE_FRAGMENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INPUT_FIELD_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INTERFACE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "MUTATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "QUERY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SCALAR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SCHEMA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SUBSCRIPTION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "UNION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          }
+        ],
         "possibleTypes": null,
-        "interfaces": [],
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
         "name": "__EnumValue",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "deprecationReason",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "isDeprecated",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Field",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "args",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -819,168 +900,198 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__InputValue",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "deprecationReason",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "isDeprecated",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "type",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__InputValue",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "defaultValue",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "type",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Schema",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "directives",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -993,58 +1104,70 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__Directive",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "mutationType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "queryType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "subscriptionType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "types",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1057,52 +1180,62 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Type",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "enumValues",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
-                "defaultValue": "false",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": "false",
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "enumValues",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1112,28 +1245,34 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__EnumValue",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "fields",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
-                "defaultValue": "false",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": "false",
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "fields",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1143,17 +1282,21 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Field",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "inputFields",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1163,17 +1306,21 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__InputValue",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "interfaces",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1183,57 +1330,68 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "kind",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "ENUM",
                 "name": "__TypeKind",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ofType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "possibleTypes",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1243,234 +1401,287 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          }
-        ]
-      },
-      {
-        "inputFields": null,
-        "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "__TypeKind",
-        "enumValues": [
-          {
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "ENUM",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INPUT_OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INTERFACE",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "LIST",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "NON_NULL",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SCALAR",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "UNION",
-            "description": null
+            "__typename": "__Field"
           }
         ],
-        "description": null,
-        "fields": null
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "ENUM",
+        "name": "__TypeKind",
+        "description": null,
+        "fields": null,
         "inputFields": null,
-        "kind": "OBJECT",
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ENUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INTERFACE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "LIST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "NON_NULL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SCALAR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "UNION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          }
+        ],
         "possibleTypes": null,
-        "interfaces": [],
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
         "name": "benchmark_metadata",
-        "enumValues": null,
         "description": "columns and relationships of \"benchmark_metadata\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "build_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "failed",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "pr_title",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "repo_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "timestamp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_aggregate",
-        "enumValues": null,
         "description": "aggregated selection of \"benchmark_metadata\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "aggregate",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_aggregate_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "nodes",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1483,41 +1694,52 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_aggregate_fields",
-        "enumValues": null,
         "description": "aggregate fields of \"benchmark_metadata\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "avg",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_avg_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "count",
+            "description": null,
             "args": [
               {
                 "name": "columns",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -1527,269 +1749,325 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "distinct",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "count",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "max",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_max_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "min",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_min_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_stddev_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_stddev_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_stddev_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "sum",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_sum_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_var_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_var_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "variance",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_variance_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_aggregate_order_by",
+        "description": "order by aggregate values of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "avg",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_avg_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "count",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "max",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_max_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "min",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_min_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_stddev_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_stddev_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_stddev_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "sum",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_sum_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_var_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_var_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "variance",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_variance_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_aggregate_order_by",
         "enumValues": null,
-        "description": "order by aggregate values of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1802,818 +2080,1028 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_insert_input",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "on_conflict",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_on_conflict",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_arr_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting array relation for remote table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_avg_fields",
-        "enumValues": null,
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_avg_order_by",
+        "description": "order by avg() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_avg_order_by",
         "enumValues": null,
-        "description": "order by avg() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"benchmark_metadata\". All fields are combined with a logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_and",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmark_metadata_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_not",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_bool_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_or",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmark_metadata_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "failed",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Boolean_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
-            "name": "pull_number",
-            "defaultValue": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "repo_id",
-            "defaultValue": null,
+            "name": "pr_title",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "pull_number",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "repo_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "timestamp_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_bool_exp",
         "enumValues": null,
-        "description": "Boolean expression to filter rows from the table \"benchmark_metadata\". All fields are combined with a logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmark_metadata_constraint",
+        "description": "unique or primary key constraints on table \"benchmark_metadata\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
+            "name": "benchmark_metadata_pkey",
+            "description": "unique or primary key constraint",
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "benchmark_metadata_pkey",
-            "description": "unique or primary key constraint"
+            "__typename": "__EnumValue"
           },
           {
+            "name": "benchmark_metadata_repo_id_commit_key",
+            "description": "unique or primary key constraint",
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "benchmark_metadata_repo_id_commit_key",
-            "description": "unique or primary key constraint"
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "unique or primary key constraints on table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_inc_input",
+        "description": "input type for incrementing integer column in table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_inc_input",
         "enumValues": null,
-        "description": "input type for incrementing integer column in table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_insert_input",
+        "description": "input type for inserting data into table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "failed",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "pr_title",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_insert_input",
         "enumValues": null,
-        "description": "input type for inserting data into table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_max_fields",
-        "enumValues": null,
         "description": "aggregate max on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "build_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "pull_number",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__Field"
           },
           {
+            "name": "pr_title",
+            "description": null,
             "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "repo_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "pull_number",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "repo_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_max_order_by",
+        "description": "order by max() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "pr_title",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_max_order_by",
         "enumValues": null,
-        "description": "order by max() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_min_fields",
-        "enumValues": null,
         "description": "aggregate min on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "build_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "pull_number",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__Field"
           },
           {
+            "name": "pr_title",
+            "description": null,
             "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "repo_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "pull_number",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "repo_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_min_order_by",
+        "description": "order by min() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "pr_title",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_min_order_by",
         "enumValues": null,
-        "description": "order by min() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_mutation_response",
-        "enumValues": null,
         "description": "response of any mutation on the table \"benchmark_metadata\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "affected_rows",
+            "description": "number of affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "number of affected rows by the mutation"
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "returning",
+            "description": "data of the affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2626,69 +3114,93 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "data of the affected rows by the mutation"
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmark_metadata_insert_input",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "on_conflict",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_on_conflict",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_obj_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting object relation for remote table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_on_conflict",
+        "description": "on conflict condition type for table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "constraint",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "ENUM",
                 "name": "benchmark_metadata_constraint",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "update_columns",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2701,1079 +3213,1285 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "benchmark_metadata_update_column",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "where",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_bool_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_on_conflict",
         "enumValues": null,
-        "description": "on conflict condition type for table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_order_by",
+        "description": "ordering options when selecting data from \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "failed",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "pr_title",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_order_by",
         "enumValues": null,
-        "description": "ordering options when selecting data from \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_pk_columns_input",
+        "description": "primary key columns input for table: \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_pk_columns_input",
         "enumValues": null,
-        "description": "primary key columns input for table: \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmark_metadata_select_column",
+        "description": "select columns of table \"benchmark_metadata\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "build_job_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "commit",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "failed",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "pr_title",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "pull_number",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "repo_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_at",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_job_id",
-            "description": "column name"
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "select columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_set_input",
+        "description": "input type for updating data in table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "failed",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
-            "name": "pull_number",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "repo_id",
-            "defaultValue": null,
+            "name": "pr_title",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "pull_number",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "repo_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_set_input",
         "enumValues": null,
-        "description": "input type for updating data in table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_stddev_fields",
-        "enumValues": null,
         "description": "aggregate stddev on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_stddev_order_by",
+        "description": "order by stddev() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_stddev_order_by",
         "enumValues": null,
-        "description": "order by stddev() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_stddev_pop_fields",
-        "enumValues": null,
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_stddev_pop_order_by",
+        "description": "order by stddev_pop() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_stddev_pop_order_by",
         "enumValues": null,
-        "description": "order by stddev_pop() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_stddev_samp_fields",
-        "enumValues": null,
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_stddev_samp_order_by",
+        "description": "order by stddev_samp() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_stddev_samp_order_by",
         "enumValues": null,
-        "description": "order by stddev_samp() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_sum_fields",
-        "enumValues": null,
         "description": "aggregate sum on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_sum_order_by",
+        "description": "order by sum() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_sum_order_by",
         "enumValues": null,
-        "description": "order by sum() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmark_metadata_update_column",
+        "description": "update columns of table \"benchmark_metadata\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "build_job_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "commit",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "failed",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "pr_title",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "pull_number",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "repo_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_at",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_job_id",
-            "description": "column name"
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "update columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_var_pop_fields",
-        "enumValues": null,
         "description": "aggregate var_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_var_pop_order_by",
+        "description": "order by var_pop() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_var_pop_order_by",
         "enumValues": null,
-        "description": "order by var_pop() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_var_samp_fields",
-        "enumValues": null,
         "description": "aggregate var_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_var_samp_order_by",
+        "description": "order by var_samp() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_var_samp_order_by",
         "enumValues": null,
-        "description": "order by var_samp() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmark_metadata_variance_fields",
-        "enumValues": null,
         "description": "aggregate variance on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmark_metadata_variance_order_by",
+        "description": "order by variance() on columns of table \"benchmark_metadata\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmark_metadata_variance_order_by",
         "enumValues": null,
-        "description": "order by variance() on columns of table \"benchmark_metadata\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks",
-        "enumValues": null,
         "description": "columns and relationships of \"benchmarks\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "benchmark_name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "build_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "duration",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "metrics",
+            "description": null,
             "args": [
               {
                 "name": "path",
-                "defaultValue": null,
+                "description": "JSON select path",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "JSON select path"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "metrics",
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "repo_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "timestamp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_aggregate",
-        "enumValues": null,
         "description": "aggregated selection of \"benchmarks\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "aggregate",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_aggregate_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "nodes",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3786,41 +4504,52 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_aggregate_fields",
-        "enumValues": null,
         "description": "aggregate fields of \"benchmarks\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "avg",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_avg_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "count",
+            "description": null,
             "args": [
               {
                 "name": "columns",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -3830,290 +4559,349 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "distinct",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "count",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "max",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_max_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "min",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_min_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "sum",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_sum_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_var_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_var_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "variance",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_variance_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_aggregate_order_by",
+        "description": "order by aggregate values of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "avg",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_avg_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "count",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "max",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_max_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "min",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_min_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "sum",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_sum_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_var_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_var_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "variance",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_variance_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_aggregate_order_by",
         "enumValues": null,
-        "description": "order by aggregate values of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_append_input",
+        "description": "append existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_append_input",
         "enumValues": null,
-        "description": "append existing jsonb value of filtered columns with new jsonb value",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4126,1123 +4914,1312 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_insert_input",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "on_conflict",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_on_conflict",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_arr_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting array relation for remote table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_avg_fields",
-        "enumValues": null,
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_avg_order_by",
+        "description": "order by avg() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_avg_order_by",
         "enumValues": null,
-        "description": "order by avg() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"benchmarks\". All fields are combined with a logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_and",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_not",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_bool_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_or",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "benchmark_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "duration",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "interval_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "jsonb_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "timestamp_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_bool_exp",
         "enumValues": null,
-        "description": "Boolean expression to filter rows from the table \"benchmarks\". All fields are combined with a logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmarks_constraint",
+        "description": "unique or primary key constraints on table \"benchmarks\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
+            "name": "prevent_duplicates",
+            "description": "unique or primary key constraint",
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "prevent_duplicates",
-            "description": "unique or primary key constraint"
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "unique or primary key constraints on table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_delete_at_path_input",
+        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_delete_at_path_input",
         "enumValues": null,
-        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_delete_elem_input",
+        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_delete_elem_input",
         "enumValues": null,
-        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_delete_key_input",
+        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_delete_key_input",
         "enumValues": null,
-        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_inc_input",
+        "description": "input type for incrementing integer column in table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_inc_input",
         "enumValues": null,
-        "description": "input type for incrementing integer column in table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_insert_input",
+        "description": "input type for inserting data into table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "duration",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_insert_input",
         "enumValues": null,
-        "description": "input type for inserting data into table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_max_fields",
-        "enumValues": null,
         "description": "aggregate max on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "benchmark_name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "build_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "repo_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_max_order_by",
+        "description": "order by max() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_max_order_by",
         "enumValues": null,
-        "description": "order by max() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_min_fields",
-        "enumValues": null,
         "description": "aggregate min on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "benchmark_name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "build_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "repo_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_job_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_min_order_by",
+        "description": "order by min() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_min_order_by",
         "enumValues": null,
-        "description": "order by min() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_mutation_response",
-        "enumValues": null,
         "description": "response of any mutation on the table \"benchmarks\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "affected_rows",
+            "description": "number of affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "number of affected rows by the mutation"
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "returning",
+            "description": "data of the affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5255,69 +6232,93 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "data of the affected rows by the mutation"
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_insert_input",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "on_conflict",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_on_conflict",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_obj_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting object relation for remote table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_on_conflict",
+        "description": "on conflict condition type for table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "constraint",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "ENUM",
                 "name": "benchmarks_constraint",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "update_columns",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5330,1174 +6331,1372 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "benchmarks_update_column",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "where",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_bool_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_on_conflict",
         "enumValues": null,
-        "description": "on conflict condition type for table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_order_by",
+        "description": "ordering options when selecting data from \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "duration",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_order_by",
         "enumValues": null,
-        "description": "ordering options when selecting data from \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_prepend_input",
+        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_prepend_input",
         "enumValues": null,
-        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmarks_select_column",
+        "description": "select columns of table \"benchmarks\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "benchmark_name",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "branch",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "build_job_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "commit",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "duration",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "metrics",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "pull_number",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "repo_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_at",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_job_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "test_index",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "test_name",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "version",
-            "description": "column name"
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "select columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_set_input",
+        "description": "input type for updating data in table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "build_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "duration",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_job_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_set_input",
         "enumValues": null,
-        "description": "input type for updating data in table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_stddev_fields",
-        "enumValues": null,
         "description": "aggregate stddev on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_stddev_order_by",
+        "description": "order by stddev() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_stddev_order_by",
         "enumValues": null,
-        "description": "order by stddev() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_stddev_pop_fields",
-        "enumValues": null,
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_stddev_pop_order_by",
+        "description": "order by stddev_pop() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_stddev_pop_order_by",
         "enumValues": null,
-        "description": "order by stddev_pop() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_stddev_samp_fields",
-        "enumValues": null,
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_stddev_samp_order_by",
+        "description": "order by stddev_samp() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_stddev_samp_order_by",
         "enumValues": null,
-        "description": "order by stddev_samp() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_sum_fields",
-        "enumValues": null,
         "description": "aggregate sum on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_sum_order_by",
+        "description": "order by sum() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_sum_order_by",
         "enumValues": null,
-        "description": "order by sum() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmarks_update_column",
+        "description": "update columns of table \"benchmarks\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "benchmark_name",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "branch",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "build_job_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "commit",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "duration",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "metrics",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "pull_number",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "repo_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_at",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_job_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "test_index",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "test_name",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "version",
-            "description": "column name"
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "update columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_var_pop_fields",
-        "enumValues": null,
         "description": "aggregate var_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_var_pop_order_by",
+        "description": "order by var_pop() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_var_pop_order_by",
         "enumValues": null,
-        "description": "order by var_pop() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_var_samp_fields",
-        "enumValues": null,
         "description": "aggregate var_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_var_samp_order_by",
+        "description": "order by var_samp() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_var_samp_order_by",
         "enumValues": null,
-        "description": "order by var_samp() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_variance_fields",
-        "enumValues": null,
         "description": "aggregate variance on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "test_index",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "version",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_variance_order_by",
+        "description": "order by variance() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "test_index",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "version",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_variance_order_by",
         "enumValues": null,
-        "description": "order by variance() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "interval",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "interval_comparison_exp",
+        "description": "expression to compare columns of type interval. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6507,55 +7706,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "interval",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6565,96 +7776,114 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "interval",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "interval_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type interval. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "jsonb",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "jsonb_comparison_exp",
+        "description": "expression to compare columns of type jsonb. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_contained_in",
-            "defaultValue": null,
+            "description": "is the column contained in the given json value",
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "is the column contained in the given json value"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_contains",
-            "defaultValue": null,
+            "description": "does the column contain the given json value at the top level",
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "does the column contain the given json value at the top level"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_has_key",
-            "defaultValue": null,
+            "description": "does the string exist as a top-level key in the column",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "does the string exist as a top-level key in the column"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_has_keys_all",
-            "defaultValue": null,
+            "description": "do all of these strings exist as top-level keys in the column",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6664,15 +7893,19 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "do all of these strings exist as top-level keys in the column"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_has_keys_any",
-            "defaultValue": null,
+            "description": "do any of these strings exist as top-level keys in the column",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6682,15 +7915,19 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "do any of these strings exist as top-level keys in the column"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6700,55 +7937,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "jsonb",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6758,116 +8007,130 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "jsonb",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "jsonb_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type jsonb. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "mutation_root",
-        "enumValues": null,
         "description": "mutation root",
         "fields": [
           {
+            "name": "delete_benchmark_metadata",
+            "description": "delete data from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be deleted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be deleted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "delete_benchmark_metadata",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "delete data from the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "delete_benchmark_metadata_by_pk",
+            "description": "delete single row from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "id",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "delete_benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "delete single row from the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "delete_benchmarks",
+            "description": "delete data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be deleted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be deleted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "delete_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "delete data from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmark_metadata",
+            "description": "insert data into the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "objects",
-                "defaultValue": null,
+                "description": "the rows to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -6880,76 +8143,92 @@
                       "ofType": {
                         "kind": "INPUT_OBJECT",
                         "name": "benchmark_metadata_insert_input",
-                        "ofType": null
-                      }
-                    }
-                  }
+                        "ofType": null,
+                        "__typename": "__Type"
+                      },
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the rows to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "on_conflict",
-                "defaultValue": null,
+                "description": "on conflict condition",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_on_conflict",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "on conflict condition"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmark_metadata",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert data into the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmark_metadata_one",
+            "description": "insert a single row into the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "object",
-                "defaultValue": null,
+                "description": "the row to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_insert_input",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the row to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "on_conflict",
-                "defaultValue": null,
+                "description": "on conflict condition",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_on_conflict",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "on conflict condition"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmark_metadata_one",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert a single row into the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmarks",
+            "description": "insert data into the table: \"benchmarks\"",
             "args": [
               {
                 "name": "objects",
-                "defaultValue": null,
+                "description": "the rows to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -6962,325 +8241,386 @@
                       "ofType": {
                         "kind": "INPUT_OBJECT",
                         "name": "benchmarks_insert_input",
-                        "ofType": null
-                      }
-                    }
-                  }
+                        "ofType": null,
+                        "__typename": "__Type"
+                      },
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the rows to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "on_conflict",
-                "defaultValue": null,
+                "description": "on conflict condition",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_on_conflict",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "on conflict condition"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert data into the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmarks_one",
+            "description": "insert a single row into the table: \"benchmarks\"",
             "args": [
               {
                 "name": "object",
-                "defaultValue": null,
+                "description": "the row to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_insert_input",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the row to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "on_conflict",
-                "defaultValue": null,
+                "description": "on conflict condition",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_on_conflict",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "on conflict condition"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmarks_one",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert a single row into the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "update_benchmark_metadata",
+            "description": "update data of the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "_inc",
-                "defaultValue": null,
+                "description": "increments the integer columns with given value of the filtered values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_inc_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "increments the integer columns with given value of the filtered values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_set",
-                "defaultValue": null,
+                "description": "sets the columns of the filtered rows to the given values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_set_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "sets the columns of the filtered rows to the given values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be updated",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be updated"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "update_benchmark_metadata",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "update data of the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "update_benchmark_metadata_by_pk",
+            "description": "update single row of the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "_inc",
-                "defaultValue": null,
+                "description": "increments the integer columns with given value of the filtered values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_inc_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "increments the integer columns with given value of the filtered values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_set",
-                "defaultValue": null,
+                "description": "sets the columns of the filtered rows to the given values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_set_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "sets the columns of the filtered rows to the given values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "pk_columns",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_pk_columns_input",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "update_benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "update single row of the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "update_benchmarks",
+            "description": "update data of the table: \"benchmarks\"",
             "args": [
               {
                 "name": "_append",
-                "defaultValue": null,
+                "description": "append existing jsonb value of filtered columns with new jsonb value",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_append_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "append existing jsonb value of filtered columns with new jsonb value"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_delete_at_path",
-                "defaultValue": null,
+                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_at_path_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_delete_elem",
-                "defaultValue": null,
+                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_elem_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_delete_key",
-                "defaultValue": null,
+                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_key_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_inc",
-                "defaultValue": null,
+                "description": "increments the integer columns with given value of the filtered values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_inc_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "increments the integer columns with given value of the filtered values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_prepend",
-                "defaultValue": null,
+                "description": "prepend existing jsonb value of filtered columns with new jsonb value",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_prepend_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "prepend existing jsonb value of filtered columns with new jsonb value"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_set",
-                "defaultValue": null,
+                "description": "sets the columns of the filtered rows to the given values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_set_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "sets the columns of the filtered rows to the given values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be updated",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be updated"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "update_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "update data of the table: \"benchmarks\""
-          }
-        ]
-      },
-      {
-        "inputFields": null,
-        "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "order_by",
-        "enumValues": [
-          {
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "asc",
-            "description": "in the ascending order, nulls last"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "asc_nulls_first",
-            "description": "in the ascending order, nulls first"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "asc_nulls_last",
-            "description": "in the ascending order, nulls last"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "desc",
-            "description": "in the descending order, nulls first"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "desc_nulls_first",
-            "description": "in the descending order, nulls first"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "desc_nulls_last",
-            "description": "in the descending order, nulls last"
+            "__typename": "__Field"
           }
         ],
-        "description": "column ordering options",
-        "fields": null
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "ENUM",
+        "name": "order_by",
+        "description": "column ordering options",
+        "fields": null,
         "inputFields": null,
-        "kind": "OBJECT",
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "asc",
+            "description": "in the ascending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "asc_nulls_first",
+            "description": "in the ascending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "asc_nulls_last",
+            "description": "in the ascending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "desc",
+            "description": "in the descending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "desc_nulls_first",
+            "description": "in the descending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "desc_nulls_last",
+            "description": "in the descending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          }
+        ],
         "possibleTypes": null,
-        "interfaces": [],
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
         "name": "query_root",
-        "enumValues": null,
         "description": "query root",
         "fields": [
           {
+            "name": "benchmark_metadata",
+            "description": "fetch data from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7290,35 +8630,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7328,26 +8676,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmark_metadata",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -7360,18 +8711,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmark_metadata_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7381,35 +8740,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7419,69 +8786,83 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmark_metadata_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmark_metadata_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmark_metadata_by_pk",
+            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns",
             "args": [
               {
                 "name": "id",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns"
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarks",
+            "description": "fetch data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7491,35 +8872,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7529,26 +8918,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -7561,18 +8953,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarks_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7582,35 +8982,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7620,53 +9028,63 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarks_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "subscription_root",
-        "enumValues": null,
         "description": "subscription root",
         "fields": [
           {
+            "name": "benchmark_metadata",
+            "description": "fetch data from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7676,35 +9094,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7714,26 +9140,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmark_metadata",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -7746,18 +9175,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmark_metadata_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7767,35 +9204,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7805,69 +9250,83 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmark_metadata_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmark_metadata_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmark_metadata\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmark_metadata_by_pk",
+            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns",
             "args": [
               {
                 "name": "id",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns"
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarks",
+            "description": "fetch data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7877,35 +9336,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7915,26 +9382,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -7947,18 +9417,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarks_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -7968,35 +9446,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8006,84 +9492,107 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarks_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
-      },
-      {
+        ],
         "inputFields": null,
-        "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "timestamp",
+        "interfaces": [],
         "enumValues": null,
-        "description": null,
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "SCALAR",
+        "name": "timestamp",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timestamp_comparison_exp",
+        "description": "expression to compare columns of type timestamp. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -8093,55 +9602,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "timestamp",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -8151,24 +9672,83 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "timestamp",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "timestamp_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type timestamp. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       }
     ],
-    "mutationType": {
-      "name": "mutation_root"
-    }
+    "directives": [
+      {
+        "name": "include",
+        "description": null,
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "args": [
+          {
+            "name": "if",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          }
+        ],
+        "__typename": "__Directive"
+      },
+      {
+        "name": "skip",
+        "description": null,
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "args": [
+          {
+            "name": "if",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          }
+        ],
+        "__typename": "__Directive"
+      }
+    ],
+    "__typename": "__Schema"
   }
 }

--- a/frontend/src/CommitInfo.res
+++ b/frontend/src/CommitInfo.res
@@ -11,6 +11,7 @@ query ($repoId: String!, $pullNumber: Int, $isMaster: Boolean!) {
     build_job_id
     run_job_id
     failed
+    pr_title
   }
 }
 `)
@@ -136,6 +137,16 @@ let make = (~repoId, ~pullNumber=?, ~benchmarks: GetBenchmarks.t, ~setOldMetrics
     showingOldMetrics(noCommitMetrics)
     let status = buildStatus(lastCommitInfo, noCommitMetrics)
     <>
+
+      <Row sx=containerSx spacing=#between alignY=#bottom>
+      {switch lastCommitInfo.pr_title {
+       | Some(title) =>
+         <Text sx=[Sx.text.lg]> title </Text>
+       | None =>
+         <Text sx=[Sx.text.bold, Sx.text.lg, Sx.text.color(Sx.gray700)]> "No data for PR Title" </Text>
+      }}
+      </Row>
+
       <Row sx=containerSx spacing=#between alignY=#bottom>
         <Column spacing=Sx.sm>
           <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.gray700)]> "Last Commit" </Text>

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -4,7 +4,7 @@ open Components
 let pullToString = ((pullNumber, prTitle, branch)) =>
   switch branch {
   | Some(branch) => "#" ++ Belt.Int.toString(pullNumber) ++ " - " ++ branch
-  | None => "#" ++ Belt.Int.toString(pullNumber) ++  "-" ++ prTitle
+  | None => "#" ++ Belt.Int.toString(pullNumber) ++  " " ++ prTitle
   }
 
 module SidebarMenuData = %graphql(`

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -1,10 +1,10 @@
 open! Prelude
 open Components
 
-let pullToString = ((pullNumber, branch)) =>
+let pullToString = ((pullNumber, prTitle, branch)) =>
   switch branch {
   | Some(branch) => "#" ++ Belt.Int.toString(pullNumber) ++ " - " ++ branch
-  | None => "#" ++ Belt.Int.toString(pullNumber)
+  | None => "#" ++ Belt.Int.toString(pullNumber) ++  "-" ++ prTitle
   }
 
 module SidebarMenuData = %graphql(`
@@ -12,6 +12,7 @@ query ($repoId: String!) {
   pullsMenuData: benchmark_metadata(distinct_on: [pull_number], where: {_and: [{repo_id: {_eq: $repoId}}, {pull_number: {_is_null: false}}]}, order_by: [{pull_number: desc}]) {
     pull_number
     branch
+    pr_title
   }  
   benchmarksMenuData: benchmarks(distinct_on: [benchmark_name], where: {repo_id: {_eq: $repoId}}, order_by: [{benchmark_name: asc_nulls_first}]) {
     benchmark_name
@@ -27,10 +28,19 @@ module PullsMenu = {
     ~selectedPull=?,
     ~selectedBenchmarkName=?,
   ) => {
-    let pullNumbers = pullsMenuData->Belt.Array.keepMap(obj => obj.pull_number)
+    let pullNumberInfos = pullsMenuData->Belt.Array.keepMap(obj => Some(obj.pull_number, obj.pr_title))
 
-    pullNumbers
-    ->Belt.Array.mapWithIndex((i, pullNumber) => {
+    pullNumberInfos
+    ->Belt.Array.mapWithIndex((i, pullNumberInfo) => {
+      let (pullNumber, prTitle) = pullNumberInfo
+      let pullNumber = switch pullNumber {
+      | Some(number) => number
+      | None => 0
+      }
+      let prTitle = switch prTitle {
+      | Some(title) => title
+      | None => ""
+      }
       <Row key={string_of_int(i)}>
         <a
           href={AppHelpers.pullUrl(~repoId, ~pull=string_of_int(pullNumber))}
@@ -39,7 +49,7 @@ module PullsMenu = {
           {Icon.github}
         </a>
         <Link
-          sx=[Sx.pb.md]
+          sx=[Sx.pb.md, Sx.text.overflowEllipsis, Sx.text.noWrapWhiteSpace, Sx.text.blockDisplay, Sx.text.hiddenOverflow]
           active={selectedPull === Some(pullNumber)}
           key={string_of_int(i)}
           href={AppRouter.RepoPull({
@@ -47,7 +57,7 @@ module PullsMenu = {
             pullNumber: pullNumber,
             benchmarkName: selectedBenchmarkName,
           })->AppRouter.path}
-          text={pullToString((pullNumber, None))}
+          text={pullToString((pullNumber, prTitle, None))}
         />
       </Row>
     })

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -28,19 +28,16 @@ module PullsMenu = {
     ~selectedPull=?,
     ~selectedBenchmarkName=?,
   ) => {
-    let pullNumberInfos = pullsMenuData->Belt.Array.keepMap(obj => Some(obj.pull_number, obj.pr_title))
+    let pullNumberInfos = pullsMenuData->Belt.Array.keepMap(obj =>
+    switch (obj.pull_number, obj.pr_title) {
+    | (Some(pullNumber), Some(prTitle)) => Some(pullNumber, prTitle)
+    | _ => None
+    })
 
     pullNumberInfos
     ->Belt.Array.mapWithIndex((i, pullNumberInfo) => {
       let (pullNumber, prTitle) = pullNumberInfo
-      let pullNumber = switch pullNumber {
-      | Some(number) => number
-      | None => 0
-      }
-      let prTitle = switch prTitle {
-      | Some(title) => title
-      | None => ""
-      }
+
       <Row key={string_of_int(i)}>
         <a
           href={AppHelpers.pullUrl(~repoId, ~pull=string_of_int(pullNumber))}

--- a/frontend/src/Sx.res
+++ b/frontend/src/Sx.res
@@ -160,6 +160,11 @@ module Make = (
     noUnderline: t,
     underline: t,
     lineThrough: t,
+    //other
+    overflowEllipsis: t,
+    noWrapWhiteSpace: t,
+    blockDisplay: t,
+    hiddenOverflow: t,
   }
 
   let text = {
@@ -199,6 +204,10 @@ module Make = (
     noUnderline: [Css.textDecoration(#none)],
     underline: [Css.textDecoration(#underline)],
     lineThrough: [Css.textDecoration(#lineThrough)],
+    overflowEllipsis:[Css.textOverflow(#ellipsis)],
+    noWrapWhiteSpace: [Css.whiteSpace(#nowrap)],
+    blockDisplay: [Css.display(#block)],
+    hiddenOverflow: [Css.overflow(#hidden)],
   }
 
   // Flex

--- a/hasura-server/metadata/tables.yaml
+++ b/hasura-server/metadata/tables.yaml
@@ -35,4 +35,5 @@
       - build_job_id
       - run_job_id
       - failed
+      - pr_title
       filter: {}

--- a/pipeline/db/migrations/20211022162244_add_title_column_to_metadata.down.sql
+++ b/pipeline/db/migrations/20211022162244_add_title_column_to_metadata.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE benchmark_metadata DROP COLUMN pr_title;

--- a/pipeline/db/migrations/20211022162244_add_title_column_to_metadata.up.sql
+++ b/pipeline/db/migrations/20211022162244_add_title_column_to_metadata.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE benchmark_metadata ADD pr_title varchar(256);

--- a/pipeline/lib/dune
+++ b/pipeline/lib/dune
@@ -3,6 +3,6 @@
  (public_name pipeline)
  (libraries current current.fs current_docker current_git current_github
    current_slack current_web dockerfile fmt.tty logs logs.fmt prometheus
-   rresult uri curly postgresql yojson str pcre)
+   rresult uri postgresql yojson str pcre)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/pipeline/lib/dune
+++ b/pipeline/lib/dune
@@ -3,4 +3,6 @@
  (public_name pipeline)
  (libraries current current.fs current_docker current_git current_github
    current_slack current_web dockerfile fmt.tty logs logs.fmt prometheus
-   rresult uri postgresql yojson str pcre))
+   rresult uri curly postgresql yojson str pcre)
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/pipeline/lib/refs.ml
+++ b/pipeline/lib/refs.ml
@@ -1,0 +1,102 @@
+module Git = Current_git
+module Github = Current_github
+
+let src = Logs.Src.create "current.git" ~doc:"OCurrent git plugin"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let ( / ) a b = Yojson.Safe.Util.member b a
+
+module Ref = struct
+  type t = [ `Ref of string | `PR of int ] [@@deriving to_yojson]
+
+  let compare = Stdlib.compare
+
+  let pp f = function `Ref r -> Fmt.string f r | `PR pr -> Fmt.pf f "PR %d" pr
+
+  let to_git = function
+    | `Ref head -> head
+    | `PR id -> Fmt.str "refs/pull/%d/head" id
+end
+
+module Commit_id = struct
+  type t = {
+    owner : string;
+    repo : string;
+    id : Ref.t;
+    hash : string;
+    committed_date : string;
+    title : string option;
+  }
+  [@@deriving to_yojson]
+
+  let to_git { owner; repo; id; hash; title = _; committed_date = _ } =
+    let repo = Fmt.str "https://github.com/%s/%s.git" owner repo in
+    let gref = Ref.to_git id in
+    Current_git.Commit_id.v ~repo ~gref ~hash
+
+  let owner_name { owner; repo; _ } = Fmt.str "%s/%s" owner repo
+
+  let uri t =
+    Uri.make ~scheme:"https" ~host:"github.com"
+      ~path:(Printf.sprintf "/%s/commit/%s/%s" t.owner t.repo t.hash)
+      ()
+
+  let pp_id = Ref.pp
+
+  let compare { owner; repo; id; hash; title = _; committed_date = _ } b =
+    match compare hash b.hash with
+    | 0 -> (
+        match Ref.compare id b.id with
+        | 0 -> compare (owner, repo) (b.owner, b.repo)
+        | x -> x)
+    | x -> x
+
+  let pp f { owner; repo; id; hash; title = _; committed_date } =
+    Fmt.pf f "%s/%s@ %a@ %s@ %s" owner repo pp_id id
+      (Astring.String.with_range ~len:8 hash)
+      committed_date
+
+  let digest t = Yojson.Safe.to_string (to_yojson t)
+end
+
+module Refs = Github.Api.Monitor (struct
+  type result = string option Github.Api.Ref_map.t
+
+  let name = "refs"
+
+  let query =
+    {|
+    repository(owner: $owner, name: $name) {
+      pullRequests(first: 100, states:[OPEN]) {
+        totalCount
+        edges {
+          node {
+            number
+            title
+          }
+        }
+      }
+    }
+  |}
+
+  let parse_pr json =
+    let open Yojson.Safe.Util in
+    let node = json / "node" in
+    let pr = node / "number" |> to_int in
+    let title = Some (node / "title" |> to_string) in
+    (`PR pr, title)
+
+  let of_yojson _ _ data =
+    let open Yojson.Safe.Util in
+    let repo = data / "repository" in
+    let prs = repo / "pullRequests" / "edges" |> to_list |> List.map parse_pr in
+    let add xs map =
+      List.fold_left
+        (fun acc (key, title) -> Github.Api.Ref_map.add key title acc)
+        map xs
+    in
+    Github.Api.Ref_map.empty |> add prs
+end)
+
+let refs t repo = Refs.get t repo

--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -7,6 +7,7 @@ type t = {
   branch : string option;
   slack_path : Fpath.t option;
   github_head : Current_github.Api.Commit.t option;
+  title : string option;
 }
 
 let default_src ?src commit =
@@ -14,8 +15,8 @@ let default_src ?src commit =
   | None -> Current_git.fetch (Current.return commit)
   | Some src -> src
 
-let v ~owner ~name ?src ~commit ?pull_number ?branch ?slack_path ?github_head ()
-    =
+let v ~owner ~name ?src ~commit ?pull_number ?branch ?slack_path ?github_head
+    ?title () =
   {
     owner;
     name;
@@ -25,6 +26,7 @@ let v ~owner ~name ?src ~commit ?pull_number ?branch ?slack_path ?github_head ()
     slack_path;
     github_head;
     src = default_src ?src commit;
+    title;
   }
 
 let owner t = t.owner
@@ -38,6 +40,8 @@ let commit t = t.commit
 let commit_hash t = Current_git.Commit_id.hash t.commit
 
 let pull_number t = t.pull_number
+
+let title t = t.title
 
 let branch t = t.branch
 

--- a/pipeline/lib/storage.ml
+++ b/pipeline/lib/storage.ml
@@ -11,6 +11,7 @@ let setup_metadata ~repository (db : Postgresql.connection) =
   let commit = Sql_util.string (Repository.commit_hash repository) in
   let branch = Sql_util.(option string) (Repository.branch repository) in
   let pull_number = Sql_util.(option int) (Repository.pull_number repository) in
+  let title = Sql_util.(option string) (Repository.title repository) in
   let query =
     (*
       When setting up metadata, we are only insert the details that we know at th
@@ -21,14 +22,14 @@ let setup_metadata ~repository (db : Postgresql.connection) =
     Fmt.str
       {|
     INSERT INTO
-    benchmark_metadata(run_at, repo_id, commit, branch, pull_number)
+    benchmark_metadata(run_at, repo_id, commit, branch, pull_number, pr_title)
     VALUES
-    (%s, %s, %s, %s, %s)
+    (%s, %s, %s, %s, %s, %s)
     ON CONFLICT(repo_id, commit) DO UPDATE
     set build_job_id=NULL, run_job_id=NULL
     RETURNING id;
     |}
-      run_at repo_id commit branch pull_number
+      run_at repo_id commit branch pull_number title
   in
   try
     let result = db#exec query in


### PR DESCRIPTION
Ocurrent fetches all the refs and PRs using the github graphql interface. The interface is abstracted out so we can get the title
making another graphql query to github. It is not possible to just make one query because all the types are not exposed by OCurrent, so we would need to do a lot of copying of types if we wanted to avoid making another query. The frontend then displays the title if it's available in the benchmark_metadata table.