### PR TITLE
Use dune build -watch instead of custom inotifywait command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 local-test-repo/.git
 *.env
 _build
+/environments/cb-dev-test.pem
+/environments/github.secret

--- a/pipeline/reload.sh
+++ b/pipeline/reload.sh
@@ -2,27 +2,30 @@
 
 COMMAND="${*@Q}"
 
+DIR=_build/default/bin
+EXE="${DIR}/main.exe"
+
 function run {
   cd /app
   sh -c "$COMMAND" &
+  cd /mnt/project
 }
 
 run
 
-cd /mnt/project
 /mnt/project/dev/github-app.sh
 
 while :
 do
-  cd /mnt/project
-
-  inotifywait -q -q -e CLOSE_WRITE \
-    lib/dune lib/*.ml lib/*.mli \
-    bin/dune bin/*.ml bin/*.mli
-
-  dune build bin/main.exe \
+  # NOTE:
+  # 1. inotifywait exits with a failure status code when main.exe gets deleted
+  #    before a rebuild. So, we watch the directory instead, and make sure the
+  #    file exists.
+  # 2. Also, we sleep for a short while, to ensure the process has been killed
+  #    before copying the new executable and trying to run it.
+  inotifywait -q -e CLOSE_WRITE "${DIR}" | grep -q main.exe \
   && (pkill -f '^/app/bin/current-bench-pipeline' || echo 'Not running?') \
   && sleep 0.1 \
-  && cp _build/default/bin/main.exe /app/bin/current-bench-pipeline \
+  && cp "${EXE}" /app/bin/current-bench-pipeline \
   && run
 done


### PR DESCRIPTION
Let dune build take care of the source files to watch, instead of listing all
the files manually in our reload.sh script