### PR TITLE
Support for opam pin-depends and depexts

### DIFF
--- a/pipeline/.ocamlformat
+++ b/pipeline/.ocamlformat
@@ -2,3 +2,4 @@ version = 0.19.0
 profile = conventional
 parse-docstrings = true
 break-infix = fit-or-vertical
+if-then-else = keyword-first

--- a/pipeline/lib/current_util.ml
+++ b/pipeline/lib/current_util.ml
@@ -1,8 +1,11 @@
 open Current.Syntax
 
 let get_job_id x =
-  let+ md = Current.Analysis.metadata x in
-  match md with Some { Current.Metadata.job_id; _ } -> job_id | None -> None
+  Current.with_context x (fun () ->
+      let+ md = Current.Analysis.metadata x in
+      match md with
+      | Some { Current.Metadata.job_id; _ } -> job_id
+      | None -> None)
 
 module Docker_util = struct
   module Docker = Current_docker.Default

--- a/pipeline/lib/logging.ml
+++ b/pipeline/lib/logging.ml
@@ -45,14 +45,13 @@ let init ?style_renderer ?level () =
     List.iter
       (fun src ->
         let name = Logs.Src.name src in
-        if
-          name = "handshake"
-          || name = "tls.tracing"
-          || name = "x509"
-          || name = "cohttp.lwt.io"
-          || name = "x509.private_key"
-          || name = "mirage-crypto-rng.lwt"
-          || name = "mirage-crypto-rng.unix"
+        if name = "handshake"
+           || name = "tls.tracing"
+           || name = "x509"
+           || name = "cohttp.lwt.io"
+           || name = "x509.private_key"
+           || name = "mirage-crypto-rng.lwt"
+           || name = "mirage-crypto-rng.unix"
         then Logs.Src.set_level src (Some Logs.Warning))
       srcs
   in

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -168,7 +168,7 @@ let pipeline ~conninfo ~docker_config ~repository =
   let serial_id = Storage.setup_metadata ~repository ~conninfo in
   let src = Repository.src repository in
   let run_args = Docker_config.run_args ~repository docker_config in
-  let dockerfile = Custom_dockerfile.dockerfile ~pool ~run_args ~repository in
+  let dockerfile = Custom_dockerfile.dockerfile ~repository in
   let current_image = Docker.build ~pool ~pull:false ~dockerfile (`Git src) in
   let* () =
     record_pipeline_stage ~stage:"build_job_id" ~serial_id ~conninfo
@@ -223,7 +223,8 @@ let github_repositories ?slack_path repo =
       let commit = Github.Api.Commit.id head in
       let repository = repository ~commit ~github_head:head ?title in
       (* If commit is more than two weeks old, then skip it.*)
-      if Github.Api.Commit.committed_date head > stale_timestamp then
+      if Github.Api.Commit.committed_date head > stale_timestamp
+      then
         match key with
         (* Skip all branches other than the default branch, and check PRs *)
         | `Ref branch when branch = default_branch ->
@@ -278,7 +279,8 @@ let process_pipeline ~docker_config ~conninfo ~source () =
     (module Repository)
     (fun repo ->
       let* repository = repo in
-      if exists ~conninfo repository then Current.ignore_value repo
+      if exists ~conninfo repository
+      then Current.ignore_value repo
       else pipeline ~conninfo ~docker_config repository)
     (repositories source)
 


### PR DESCRIPTION
The current strategy for optimizing opam dependencies during the docker build has some limitations: no support for system dependencies and opam pin-depends. It also requires to run docker just for the analysis.

This PR uses a simpler tactic: we copy only the `.opam` files in the docker, pin them and run the installations. If the opam files did not change, then the docker cache will be able to reuse the previous result.

The code had some special support for `*-bench.opam` files, but looking at irmin for example, their `-bench.opam` requires the other packages to be present (so we have to copy and pin everything anyway).