### PR TITLE
Correctly handle displaying information about cancelled builds in the UI

### DIFF
--- a/frontend/graphql_schema.json
+++ b/frontend/graphql_schema.json
@@ -1,247 +1,256 @@
 {
   "__schema": {
+    "directives": [
+      {
+        "args": [
+          {
+            "name": "if",
+            "defaultValue": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "description": null
+          }
+        ],
+        "name": "include",
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "description": null
+      },
+      {
+        "args": [
+          {
+            "name": "if",
+            "defaultValue": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "description": null
+          }
+        ],
+        "name": "skip",
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "description": null
+      }
+    ],
     "queryType": {
-      "name": "query_root",
-      "__typename": "__Type"
-    },
-    "mutationType": {
-      "name": "mutation_root",
-      "__typename": "__Type"
+      "name": "query_root"
     },
     "subscriptionType": {
-      "name": "subscription_root",
-      "__typename": "__Type"
+      "name": "subscription_root"
     },
     "types": [
       {
+        "inputFields": null,
         "kind": "SCALAR",
+        "possibleTypes": null,
+        "interfaces": null,
         "name": "Boolean",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
         "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": null,
+        "fields": null
       },
       {
+        "inputFields": [
+          {
+            "name": "_eq",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "_gt",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "_gte",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "_in",
+            "defaultValue": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            "description": null
+          },
+          {
+            "name": "_is_null",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "_lt",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "_lte",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "_neq",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "_nin",
+            "defaultValue": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            "description": null
+          }
+        ],
         "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
         "name": "Boolean_comparison_exp",
+        "enumValues": null,
         "description": "expression to compare columns of type Boolean. All fields are combined with logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_eq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_gt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_gte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_in",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_is_null",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_lt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_lte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_neq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "_nin",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "SCALAR",
+        "possibleTypes": null,
+        "interfaces": null,
         "name": "Float",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
         "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": null,
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "SCALAR",
+        "possibleTypes": null,
+        "interfaces": null,
         "name": "ID",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
         "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": null,
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "SCALAR",
-        "name": "Int",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "Int",
+        "enumValues": null,
+        "description": null,
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "Int_comparison_exp",
-        "description": "expression to compare columns of type Int. All fields are combined with logical 'AND'.",
-        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_in",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -251,67 +260,55 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_is_null",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_neq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nin",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -321,90 +318,76 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "SCALAR",
-        "name": "String",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
         "kind": "INPUT_OBJECT",
-        "name": "String_comparison_exp",
-        "description": "expression to compare columns of type String. All fields are combined with logical 'AND'.",
-        "fields": null,
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "Int_comparison_exp",
+        "enumValues": null,
+        "description": "expression to compare columns of type Int. All fields are combined with logical 'AND'.",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "SCALAR",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "String",
+        "enumValues": null,
+        "description": null,
+        "fields": null
+      },
+      {
         "inputFields": [
           {
             "name": "_eq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_ilike",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_in",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -414,91 +397,75 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_is_null",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_like",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_neq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nilike",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nin",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -508,67 +475,65 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nlike",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nsimilar",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_similar",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "String_comparison_exp",
+        "enumValues": null,
+        "description": "expression to compare columns of type String. All fields are combined with logical 'AND'.",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "__Directive",
+        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "name": "args",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "args",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -581,37 +546,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__InputValue",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "description",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "description",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "locations",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "locations",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -624,270 +582,231 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "__DirectiveLocation",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "ENUM",
-        "name": "__DirectiveLocation",
-        "description": null,
-        "fields": null,
         "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
         "interfaces": null,
+        "name": "__DirectiveLocation",
         "enumValues": [
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "ARGUMENT_DEFINITION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "ENUM",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "ENUM_VALUE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "FIELD",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "FIELD_DEFINITION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "FRAGMENT_DEFINITION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "FRAGMENT_SPREAD",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "INLINE_FRAGMENT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "INPUT_FIELD_DEFINITION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "INPUT_OBJECT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "INTERFACE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "MUTATION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "OBJECT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "QUERY",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "SCALAR",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "SCHEMA",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "SUBSCRIPTION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
-            "name": "UNION",
-            "description": null,
             "isDeprecated": false,
             "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "name": "UNION",
+            "description": null
           }
         ],
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": null,
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "__EnumValue",
+        "enumValues": null,
         "description": null,
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "deprecationReason",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "description",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "isDeprecated",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "isDeprecated",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "__Field",
+        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "name": "args",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "args",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -900,198 +819,168 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__InputValue",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "deprecationReason",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "description",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "isDeprecated",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "isDeprecated",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "type",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "type",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "__InputValue",
+        "enumValues": null,
         "description": null,
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "defaultValue",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "description",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "type",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "type",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "__Schema",
+        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "name": "directives",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "directives",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1104,70 +993,58 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__Directive",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "mutationType",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "mutationType",
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "queryType",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "queryType",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "subscriptionType",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "subscriptionType",
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "types",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "types",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1180,62 +1057,52 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__Type",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "__Type",
+        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "name": "description",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "description",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "enumValues",
-            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
-                "description": null,
+                "defaultValue": "false",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": "false",
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "enumValues",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1245,34 +1112,28 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__EnumValue",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "fields",
-            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
-                "description": null,
+                "defaultValue": "false",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": "false",
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "fields",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1282,21 +1143,17 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Field",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "inputFields",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "inputFields",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1306,21 +1163,17 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__InputValue",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "interfaces",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "interfaces",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1330,68 +1183,57 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "kind",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "kind",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "ENUM",
                 "name": "__TypeKind",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "ofType",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "ofType",
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "possibleTypes",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "possibleTypes",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1401,287 +1243,270 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "ENUM",
-        "name": "__TypeKind",
-        "description": null,
-        "fields": null,
         "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
         "interfaces": null,
+        "name": "__TypeKind",
         "enumValues": [
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "ENUM",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "INPUT_OBJECT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "INTERFACE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "LIST",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "NON_NULL",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "OBJECT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "SCALAR",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
-            "name": "UNION",
-            "description": null,
             "isDeprecated": false,
             "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "name": "UNION",
+            "description": null
           }
         ],
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": null,
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmark_metadata",
+        "enumValues": null,
         "description": "columns and relationships of \"benchmark_metadata\"",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "commit",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancel_reason",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancelled",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "commit",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "failed",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "failed",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "pr_title",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pr_title",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "pull_number",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "repo_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "repo_id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_at",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_at",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "timestamp",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_job_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_job_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmark_metadata_aggregate",
+        "enumValues": null,
         "description": "aggregated selection of \"benchmark_metadata\"",
         "fields": [
           {
-            "name": "aggregate",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "aggregate",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_aggregate_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "nodes",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "nodes",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1694,52 +1519,41 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmark_metadata_aggregate_fields",
+        "enumValues": null,
         "description": "aggregate fields of \"benchmark_metadata\"",
         "fields": [
           {
-            "name": "avg",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "avg",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_avg_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "count",
-            "description": null,
             "args": [
               {
                 "name": "columns",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -1749,325 +1563,269 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               },
               {
                 "name": "distinct",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "count",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "max",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "max",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_max_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "min",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "min",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_min_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "stddev",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "stddev",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_stddev_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "stddev_pop",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "stddev_pop",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_stddev_pop_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "stddev_samp",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "stddev_samp",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_stddev_samp_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "sum",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "sum",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_sum_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "var_pop",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "var_pop",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_var_pop_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "var_samp",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "var_samp",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_var_samp_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "variance",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "variance",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_variance_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_aggregate_order_by",
-        "description": "order by aggregate values of table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "avg",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_avg_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "count",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "max",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_max_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "min",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_min_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "stddev",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_stddev_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "stddev_pop",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_stddev_pop_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "stddev_samp",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_stddev_samp_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "sum",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_sum_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "var_pop",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_var_pop_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "var_samp",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_var_samp_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "variance",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_variance_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_aggregate_order_by",
+        "enumValues": null,
+        "description": "order by aggregate values of table \"benchmark_metadata\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_arr_rel_insert_input",
-        "description": "input type for inserting array relation for remote table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2080,1028 +1838,966 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_insert_input",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "on_conflict",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_on_conflict",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_arr_rel_insert_input",
+        "enumValues": null,
+        "description": "input type for inserting array relation for remote table \"benchmark_metadata\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmark_metadata_avg_fields",
+        "enumValues": null,
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "name": "id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "pull_number",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_avg_order_by",
-        "description": "order by avg() on columns of table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_avg_order_by",
+        "enumValues": null,
+        "description": "order by avg() on columns of table \"benchmark_metadata\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_bool_exp",
-        "description": "Boolean expression to filter rows from the table \"benchmark_metadata\". All fields are combined with a logical 'AND'.",
-        "fields": null,
         "inputFields": [
           {
             "name": "_and",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmark_metadata_bool_exp",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_not",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_bool_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_or",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmark_metadata_bool_exp",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
-            "name": "commit",
-            "description": null,
+            "name": "cancel_reason",
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
-            "name": "failed",
-            "description": null,
+            "name": "cancelled",
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Boolean_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pr_title",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "repo_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "run_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamp_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "run_job_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "ENUM",
-        "name": "benchmark_metadata_constraint",
-        "description": "unique or primary key constraints on table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "benchmark_metadata_pkey",
-            "description": "unique or primary key constraint",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "benchmark_metadata_repo_id_commit_key",
-            "description": "unique or primary key constraint",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          }
-        ],
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_inc_input",
-        "description": "input type for incrementing integer column in table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_insert_input",
-        "description": "input type for inserting data into table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "branch",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "build_job_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
             "defaultValue": null,
-            "__typename": "__InputValue"
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
           },
           {
             "name": "failed",
-            "description": null,
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pr_title",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "repo_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "run_at",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamp_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "run_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_bool_exp",
+        "enumValues": null,
+        "description": "Boolean expression to filter rows from the table \"benchmark_metadata\". All fields are combined with a logical 'AND'.",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_constraint",
+        "enumValues": [
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata_pkey",
+            "description": "unique or primary key constraint"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata_repo_id_commit_key",
+            "description": "unique or primary key constraint"
+          }
+        ],
+        "description": "unique or primary key constraints on table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_inc_input",
+        "enumValues": null,
+        "description": "input type for incrementing integer column in table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": [
+          {
+            "name": "branch",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "build_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "cancel_reason",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "cancelled",
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
+            "description": null
+          },
+          {
+            "name": "commit",
             "defaultValue": null,
-            "__typename": "__InputValue"
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "failed",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
           },
           {
             "name": "id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pr_title",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_insert_input",
+        "enumValues": null,
+        "description": "input type for inserting data into table \"benchmark_metadata\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmark_metadata_max_fields",
+        "enumValues": null,
         "description": "aggregate max on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancel_reason",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "commit",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pr_title",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "pull_number",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "repo_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "repo_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_at",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_at",
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_job_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_job_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_max_order_by",
-        "description": "order by max() on columns of table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
+            "description": null
+          },
+          {
+            "name": "cancel_reason",
             "defaultValue": null,
-            "__typename": "__InputValue"
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pr_title",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_max_order_by",
+        "enumValues": null,
+        "description": "order by max() on columns of table \"benchmark_metadata\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmark_metadata_min_fields",
+        "enumValues": null,
         "description": "aggregate min on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancel_reason",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "commit",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pr_title",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "pull_number",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "repo_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "repo_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_at",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_at",
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_job_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_job_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_min_order_by",
-        "description": "order by min() on columns of table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
+            "description": null
+          },
+          {
+            "name": "cancel_reason",
             "defaultValue": null,
-            "__typename": "__InputValue"
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pr_title",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_min_order_by",
+        "enumValues": null,
+        "description": "order by min() on columns of table \"benchmark_metadata\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmark_metadata_mutation_response",
+        "enumValues": null,
         "description": "response of any mutation on the table \"benchmark_metadata\"",
         "fields": [
           {
-            "name": "affected_rows",
-            "description": "number of affected rows by the mutation",
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "affected_rows",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "number of affected rows by the mutation"
           },
           {
-            "name": "returning",
-            "description": "data of the affected rows by the mutation",
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "returning",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3114,93 +2810,69 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "data of the affected rows by the mutation"
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_obj_rel_insert_input",
-        "description": "input type for inserting object relation for remote table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmark_metadata_insert_input",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "on_conflict",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_on_conflict",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_obj_rel_insert_input",
+        "enumValues": null,
+        "description": "input type for inserting object relation for remote table \"benchmark_metadata\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_on_conflict",
-        "description": "on conflict condition type for table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "constraint",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "ENUM",
                 "name": "benchmark_metadata_constraint",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "update_columns",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3213,1285 +2885,1175 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "benchmark_metadata_update_column",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "where",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmark_metadata_bool_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_on_conflict",
+        "enumValues": null,
+        "description": "on conflict condition type for table \"benchmark_metadata\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_order_by",
-        "description": "ordering options when selecting data from \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
+            "description": null
+          },
+          {
+            "name": "cancel_reason",
             "defaultValue": null,
-            "__typename": "__InputValue"
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "cancelled",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "failed",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pr_title",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_order_by",
+        "enumValues": null,
+        "description": "ordering options when selecting data from \"benchmark_metadata\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_pk_columns_input",
-        "description": "primary key columns input for table: \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmark_metadata_pk_columns_input",
+        "enumValues": null,
+        "description": "primary key columns input for table: \"benchmark_metadata\"",
+        "fields": null
       },
       {
-        "kind": "ENUM",
-        "name": "benchmark_metadata_select_column",
-        "description": "select columns of table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
         "interfaces": null,
+        "name": "benchmark_metadata_select_column",
         "enumValues": [
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancel_reason",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancelled",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "commit",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "failed",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pr_title",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "repo_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "run_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
-            "name": "run_job_id",
-            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "name": "run_job_id",
+            "description": "column name"
           }
         ],
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": "select columns of table \"benchmark_metadata\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_set_input",
-        "description": "input type for updating data in table \"benchmark_metadata\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
-            "name": "commit",
-            "description": null,
+            "name": "cancel_reason",
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
-            "name": "failed",
-            "description": null,
+            "name": "cancelled",
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pr_title",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "repo_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "run_at",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "run_job_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmark_metadata_stddev_fields",
-        "description": "aggregate stddev on columns",
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_stddev_order_by",
-        "description": "order by stddev() on columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmark_metadata_stddev_pop_fields",
-        "description": "aggregate stddev_pop on columns",
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_stddev_pop_order_by",
-        "description": "order by stddev_pop() on columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmark_metadata_stddev_samp_fields",
-        "description": "aggregate stddev_samp on columns",
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_stddev_samp_order_by",
-        "description": "order by stddev_samp() on columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmark_metadata_sum_fields",
-        "description": "aggregate sum on columns",
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_sum_order_by",
-        "description": "order by sum() on columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "ENUM",
-        "name": "benchmark_metadata_update_column",
-        "description": "update columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "branch",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "build_job_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
           },
           {
             "name": "failed",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "pr_title",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "pull_number",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "repo_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "run_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          },
-          {
-            "name": "run_job_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
-          }
-        ],
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmark_metadata_var_pop_fields",
-        "description": "aggregate var_pop on columns",
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_var_pop_order_by",
-        "description": "order by var_pop() on columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
             "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmark_metadata_var_samp_fields",
-        "description": "aggregate var_samp on columns",
-        "fields": [
+            "description": null
+          },
           {
             "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_var_samp_order_by",
-        "description": "order by var_samp() on columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
             "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmark_metadata_variance_fields",
-        "description": "aggregate variance on columns",
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmark_metadata_variance_order_by",
-        "description": "order by variance() on columns of table \"benchmark_metadata\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
-        "name": "benchmarks",
-        "description": "columns and relationships of \"benchmarks\"",
-        "fields": [
-          {
-            "name": "benchmark_name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "branch",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "build_job_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "commit",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "duration",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "metrics",
-            "description": null,
-            "args": [
-              {
-                "name": "path",
-                "description": "JSON select path",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "defaultValue": null,
-                "__typename": "__InputValue"
-              }
-            ],
-            "type": {
-              "kind": "SCALAR",
-              "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
-            },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
-          },
-          {
-            "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
+          },
+          {
+            "name": "pr_title",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "run_at",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "run_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_set_input",
+        "enumValues": null,
+        "description": "input type for updating data in table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmark_metadata_stddev_fields",
+        "enumValues": null,
+        "description": "aggregate stddev on columns",
+        "fields": [
+          {
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          }
+        ]
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_stddev_order_by",
+        "enumValues": null,
+        "description": "order by stddev() on columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmark_metadata_stddev_pop_fields",
+        "enumValues": null,
+        "description": "aggregate stddev_pop on columns",
+        "fields": [
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          }
+        ]
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_stddev_pop_order_by",
+        "enumValues": null,
+        "description": "order by stddev_pop() on columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmark_metadata_stddev_samp_fields",
+        "enumValues": null,
+        "description": "aggregate stddev_samp on columns",
+        "fields": [
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          }
+        ]
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_stddev_samp_order_by",
+        "enumValues": null,
+        "description": "order by stddev_samp() on columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmark_metadata_sum_fields",
+        "enumValues": null,
+        "description": "aggregate sum on columns",
+        "fields": [
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "description": null
+          }
+        ]
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_sum_order_by",
+        "enumValues": null,
+        "description": "order by sum() on columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_update_column",
+        "enumValues": [
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "branch",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "build_job_id",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancel_reason",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "cancelled",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "commit",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "failed",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pr_title",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "repo_id",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_at",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_job_id",
+            "description": "column name"
+          }
+        ],
+        "description": "update columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmark_metadata_var_pop_fields",
+        "enumValues": null,
+        "description": "aggregate var_pop on columns",
+        "fields": [
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          }
+        ]
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_var_pop_order_by",
+        "enumValues": null,
+        "description": "order by var_pop() on columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmark_metadata_var_samp_fields",
+        "enumValues": null,
+        "description": "aggregate var_samp on columns",
+        "fields": [
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          }
+        ]
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_var_samp_order_by",
+        "enumValues": null,
+        "description": "order by var_samp() on columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmark_metadata_variance_fields",
+        "enumValues": null,
+        "description": "aggregate variance on columns",
+        "fields": [
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "description": null
+          }
+        ]
+      },
+      {
+        "inputFields": [
+          {
+            "name": "id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_number",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          }
+        ],
+        "kind": "INPUT_OBJECT",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmark_metadata_variance_order_by",
+        "enumValues": null,
+        "description": "order by variance() on columns of table \"benchmark_metadata\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
+        "name": "benchmarks",
+        "enumValues": null,
+        "description": "columns and relationships of \"benchmarks\"",
+        "fields": [
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "branch",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "build_job_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "commit",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_at",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "duration",
+            "type": {
+              "kind": "SCALAR",
+              "name": "interval",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [
+              {
+                "name": "path",
+                "defaultValue": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "description": "JSON select path"
+              }
+            ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "metrics",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "repo_id",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_at",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "timestamp",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_job_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_job_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "test_index",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "test_index",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "test_name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "test_name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_aggregate",
+        "enumValues": null,
         "description": "aggregated selection of \"benchmarks\"",
         "fields": [
           {
-            "name": "aggregate",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "aggregate",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_aggregate_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "nodes",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "nodes",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4504,52 +4066,41 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_aggregate_fields",
+        "enumValues": null,
         "description": "aggregate fields of \"benchmarks\"",
         "fields": [
           {
-            "name": "avg",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "avg",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_avg_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "count",
-            "description": null,
             "args": [
               {
                 "name": "columns",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -4559,349 +4110,290 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               },
               {
                 "name": "distinct",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "count",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "max",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "max",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_max_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "min",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "min",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_min_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "stddev",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "stddev",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "stddev_pop",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "stddev_pop",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_pop_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "stddev_samp",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "stddev_samp",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_samp_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "sum",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "sum",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_sum_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "var_pop",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "var_pop",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_var_pop_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "var_samp",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "var_samp",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_var_samp_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "variance",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "variance",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_variance_fields",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_aggregate_order_by",
-        "description": "order by aggregate values of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "avg",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_avg_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "count",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "max",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_max_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "min",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_min_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "stddev",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "stddev_pop",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_pop_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "stddev_samp",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_samp_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "sum",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_sum_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "var_pop",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_var_pop_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "var_samp",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_var_samp_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "variance",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_variance_order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_aggregate_order_by",
+        "enumValues": null,
+        "description": "order by aggregate values of table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_append_input",
-        "description": "append existing jsonb value of filtered columns with new jsonb value",
-        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_append_input",
+        "enumValues": null,
+        "description": "append existing jsonb value of filtered columns with new jsonb value",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_arr_rel_insert_input",
-        "description": "input type for inserting array relation for remote table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4914,1312 +4406,1123 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_insert_input",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "on_conflict",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_on_conflict",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_arr_rel_insert_input",
+        "enumValues": null,
+        "description": "input type for inserting array relation for remote table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_avg_fields",
+        "enumValues": null,
         "description": "aggregate avg on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_avg_order_by",
-        "description": "order by avg() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_avg_order_by",
+        "enumValues": null,
+        "description": "order by avg() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_bool_exp",
-        "description": "Boolean expression to filter rows from the table \"benchmarks\". All fields are combined with a logical 'AND'.",
-        "fields": null,
         "inputFields": [
           {
             "name": "_and",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_bool_exp",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_not",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_bool_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_or",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_bool_exp",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "benchmark_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "duration",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "interval_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "jsonb_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "timestamp_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_bool_exp",
+        "enumValues": null,
+        "description": "Boolean expression to filter rows from the table \"benchmarks\". All fields are combined with a logical 'AND'.",
+        "fields": null
       },
       {
-        "kind": "ENUM",
-        "name": "benchmarks_constraint",
-        "description": "unique or primary key constraints on table \"benchmarks\"",
-        "fields": null,
         "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
         "interfaces": null,
+        "name": "benchmarks_constraint",
         "enumValues": [
           {
-            "name": "prevent_duplicates",
-            "description": "unique or primary key constraint",
             "isDeprecated": false,
             "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "name": "prevent_duplicates",
+            "description": "unique or primary key constraint"
           }
         ],
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": "unique or primary key constraints on table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_delete_at_path_input",
-        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
-        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_delete_at_path_input",
+        "enumValues": null,
+        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_delete_elem_input",
-        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
-        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_delete_elem_input",
+        "enumValues": null,
+        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_delete_key_input",
-        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
-        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_delete_key_input",
+        "enumValues": null,
+        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_inc_input",
-        "description": "input type for incrementing integer column in table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_inc_input",
+        "enumValues": null,
+        "description": "input type for incrementing integer column in table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_insert_input",
-        "description": "input type for inserting data into table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "duration",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_insert_input",
+        "enumValues": null,
+        "description": "input type for inserting data into table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_max_fields",
+        "enumValues": null,
         "description": "aggregate max on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "benchmark_name",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "commit",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "pull_number",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "repo_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "repo_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_at",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_at",
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "run_job_id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "test_name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "test_name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_max_order_by",
-        "description": "order by max() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_max_order_by",
+        "enumValues": null,
+        "description": "order by max() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_min_fields",
+        "enumValues": null,
         "description": "aggregate min on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "benchmark_name",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "commit",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "pull_number",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_number",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "repo_id",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "repo_id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "run_at",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "run_at",
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "run_job_id",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "test_name",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "test_name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_min_order_by",
-        "description": "order by min() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_min_order_by",
+        "enumValues": null,
+        "description": "order by min() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_mutation_response",
+        "enumValues": null,
         "description": "response of any mutation on the table \"benchmarks\"",
         "fields": [
           {
-            "name": "affected_rows",
-            "description": "number of affected rows by the mutation",
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "affected_rows",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "number of affected rows by the mutation"
           },
           {
-            "name": "returning",
-            "description": "data of the affected rows by the mutation",
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "returning",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6232,93 +5535,69 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "data of the affected rows by the mutation"
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_obj_rel_insert_input",
-        "description": "input type for inserting object relation for remote table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_insert_input",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "on_conflict",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_on_conflict",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_obj_rel_insert_input",
+        "enumValues": null,
+        "description": "input type for inserting object relation for remote table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_on_conflict",
-        "description": "on conflict condition type for table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "constraint",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "ENUM",
                 "name": "benchmarks_constraint",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "update_columns",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6331,1372 +5610,1174 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "benchmarks_update_column",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "where",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_bool_exp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_on_conflict",
+        "enumValues": null,
+        "description": "on conflict condition type for table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_order_by",
-        "description": "ordering options when selecting data from \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "duration",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_order_by",
+        "enumValues": null,
+        "description": "ordering options when selecting data from \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_prepend_input",
-        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
-        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_prepend_input",
+        "enumValues": null,
+        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+        "fields": null
       },
       {
-        "kind": "ENUM",
-        "name": "benchmarks_select_column",
-        "description": "select columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
         "interfaces": null,
+        "name": "benchmarks_select_column",
         "enumValues": [
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "benchmark_name",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "commit",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "duration",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "metrics",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "repo_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "run_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "run_job_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_name",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
-            "name": "version",
-            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "name": "version",
+            "description": "column name"
           }
         ],
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": "select columns of table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_set_input",
-        "description": "input type for updating data in table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "benchmark_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "branch",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "build_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "commit",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "duration",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "metrics",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "repo_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_at",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "run_job_id",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_name",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_set_input",
+        "enumValues": null,
+        "description": "input type for updating data in table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_stddev_fields",
+        "enumValues": null,
         "description": "aggregate stddev on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_stddev_order_by",
-        "description": "order by stddev() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_stddev_order_by",
+        "enumValues": null,
+        "description": "order by stddev() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_stddev_pop_fields",
+        "enumValues": null,
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_stddev_pop_order_by",
-        "description": "order by stddev_pop() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_stddev_pop_order_by",
+        "enumValues": null,
+        "description": "order by stddev_pop() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_stddev_samp_fields",
+        "enumValues": null,
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_stddev_samp_order_by",
-        "description": "order by stddev_samp() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_stddev_samp_order_by",
+        "enumValues": null,
+        "description": "order by stddev_samp() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_sum_fields",
+        "enumValues": null,
         "description": "aggregate sum on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_sum_order_by",
-        "description": "order by sum() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_sum_order_by",
+        "enumValues": null,
+        "description": "order by sum() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
-        "kind": "ENUM",
-        "name": "benchmarks_update_column",
-        "description": "update columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
         "interfaces": null,
+        "name": "benchmarks_update_column",
         "enumValues": [
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "benchmark_name",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "branch",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "build_job_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "commit",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "duration",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "metrics",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "repo_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "run_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "run_job_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_name",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "column name"
           },
           {
-            "name": "version",
-            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "name": "version",
+            "description": "column name"
           }
         ],
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": "update columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_var_pop_fields",
+        "enumValues": null,
         "description": "aggregate var_pop on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_var_pop_order_by",
-        "description": "order by var_pop() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_var_pop_order_by",
+        "enumValues": null,
+        "description": "order by var_pop() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_var_samp_fields",
+        "enumValues": null,
         "description": "aggregate var_samp on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_var_samp_order_by",
-        "description": "order by var_samp() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "benchmarks_var_samp_order_by",
+        "enumValues": null,
+        "description": "order by var_samp() on columns of table \"benchmarks\"",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "benchmarks_variance_fields",
+        "enumValues": null,
         "description": "aggregate variance on columns",
         "fields": [
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
-            "description": null,
-            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           },
           {
-            "name": "version",
-            "description": null,
             "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "version",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": null
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "benchmarks_variance_order_by",
-        "description": "order by variance() on columns of table \"benchmarks\"",
-        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "test_index",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "version",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "SCALAR",
-        "name": "interval",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
         "kind": "INPUT_OBJECT",
-        "name": "interval_comparison_exp",
-        "description": "expression to compare columns of type interval. All fields are combined with logical 'AND'.",
-        "fields": null,
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "benchmarks_variance_order_by",
+        "enumValues": null,
+        "description": "order by variance() on columns of table \"benchmarks\"",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "SCALAR",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "interval",
+        "enumValues": null,
+        "description": null,
+        "fields": null
+      },
+      {
         "inputFields": [
           {
             "name": "_eq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_in",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -7706,67 +6787,55 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "interval",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_is_null",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_neq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "interval",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nin",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -7776,114 +6845,96 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "interval",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "SCALAR",
-        "name": "jsonb",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
         "kind": "INPUT_OBJECT",
-        "name": "jsonb_comparison_exp",
-        "description": "expression to compare columns of type jsonb. All fields are combined with logical 'AND'.",
-        "fields": null,
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "interval_comparison_exp",
+        "enumValues": null,
+        "description": "expression to compare columns of type interval. All fields are combined with logical 'AND'.",
+        "fields": null
+      },
+      {
+        "inputFields": null,
+        "kind": "SCALAR",
+        "possibleTypes": null,
+        "interfaces": null,
+        "name": "jsonb",
+        "enumValues": null,
+        "description": null,
+        "fields": null
+      },
+      {
         "inputFields": [
           {
             "name": "_contained_in",
-            "description": "is the column contained in the given json value",
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": "is the column contained in the given json value"
           },
           {
             "name": "_contains",
-            "description": "does the column contain the given json value at the top level",
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": "does the column contain the given json value at the top level"
           },
           {
             "name": "_eq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_has_key",
-            "description": "does the string exist as a top-level key in the column",
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": "does the string exist as a top-level key in the column"
           },
           {
             "name": "_has_keys_all",
-            "description": "do all of these strings exist as top-level keys in the column",
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -7893,19 +6944,15 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": "do all of these strings exist as top-level keys in the column"
           },
           {
             "name": "_has_keys_any",
-            "description": "do any of these strings exist as top-level keys in the column",
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -7915,19 +6962,15 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": "do any of these strings exist as top-level keys in the column"
           },
           {
             "name": "_in",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -7937,67 +6980,55 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "jsonb",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_is_null",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_neq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nin",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -8007,130 +7038,116 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "jsonb",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "jsonb_comparison_exp",
+        "enumValues": null,
+        "description": "expression to compare columns of type jsonb. All fields are combined with logical 'AND'.",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "mutation_root",
+        "enumValues": null,
         "description": "mutation root",
         "fields": [
           {
-            "name": "delete_benchmark_metadata",
-            "description": "delete data from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "where",
-                "description": "filter the rows which have to be deleted",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_bool_exp",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows which have to be deleted"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "delete_benchmark_metadata",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_mutation_response",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "delete data from the table: \"benchmark_metadata\""
           },
           {
-            "name": "delete_benchmark_metadata_by_pk",
-            "description": "delete single row from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "id",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "delete_benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "delete single row from the table: \"benchmark_metadata\""
           },
           {
-            "name": "delete_benchmarks",
-            "description": "delete data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "where",
-                "description": "filter the rows which have to be deleted",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_bool_exp",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows which have to be deleted"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "delete_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "delete data from the table: \"benchmarks\""
           },
           {
-            "name": "insert_benchmark_metadata",
-            "description": "insert data into the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "objects",
-                "description": "the rows to be inserted",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -8143,92 +7160,76 @@
                       "ofType": {
                         "kind": "INPUT_OBJECT",
                         "name": "benchmark_metadata_insert_input",
-                        "ofType": null,
-                        "__typename": "__Type"
-                      },
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                        "ofType": null
+                      }
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "the rows to be inserted"
               },
               {
                 "name": "on_conflict",
-                "description": "on conflict condition",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_on_conflict",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "on conflict condition"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "insert_benchmark_metadata",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_mutation_response",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "insert data into the table: \"benchmark_metadata\""
           },
           {
-            "name": "insert_benchmark_metadata_one",
-            "description": "insert a single row into the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "object",
-                "description": "the row to be inserted",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_insert_input",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "the row to be inserted"
               },
               {
                 "name": "on_conflict",
-                "description": "on conflict condition",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_on_conflict",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "on conflict condition"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "insert_benchmark_metadata_one",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "insert a single row into the table: \"benchmark_metadata\""
           },
           {
-            "name": "insert_benchmarks",
-            "description": "insert data into the table: \"benchmarks\"",
             "args": [
               {
                 "name": "objects",
-                "description": "the rows to be inserted",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -8241,386 +7242,325 @@
                       "ofType": {
                         "kind": "INPUT_OBJECT",
                         "name": "benchmarks_insert_input",
-                        "ofType": null,
-                        "__typename": "__Type"
-                      },
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                        "ofType": null
+                      }
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "the rows to be inserted"
               },
               {
                 "name": "on_conflict",
-                "description": "on conflict condition",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_on_conflict",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "on conflict condition"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "insert_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "insert data into the table: \"benchmarks\""
           },
           {
-            "name": "insert_benchmarks_one",
-            "description": "insert a single row into the table: \"benchmarks\"",
             "args": [
               {
                 "name": "object",
-                "description": "the row to be inserted",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_insert_input",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "the row to be inserted"
               },
               {
                 "name": "on_conflict",
-                "description": "on conflict condition",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_on_conflict",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "on conflict condition"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "insert_benchmarks_one",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "insert a single row into the table: \"benchmarks\""
           },
           {
-            "name": "update_benchmark_metadata",
-            "description": "update data of the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "_inc",
-                "description": "increments the integer columns with given value of the filtered values",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_inc_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "increments the integer columns with given value of the filtered values"
               },
               {
                 "name": "_set",
-                "description": "sets the columns of the filtered rows to the given values",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_set_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sets the columns of the filtered rows to the given values"
               },
               {
                 "name": "where",
-                "description": "filter the rows which have to be updated",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_bool_exp",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows which have to be updated"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "update_benchmark_metadata",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata_mutation_response",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "update data of the table: \"benchmark_metadata\""
           },
           {
-            "name": "update_benchmark_metadata_by_pk",
-            "description": "update single row of the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "_inc",
-                "description": "increments the integer columns with given value of the filtered values",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_inc_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "increments the integer columns with given value of the filtered values"
               },
               {
                 "name": "_set",
-                "description": "sets the columns of the filtered rows to the given values",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_set_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sets the columns of the filtered rows to the given values"
               },
               {
                 "name": "pk_columns",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmark_metadata_pk_columns_input",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "update_benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "update single row of the table: \"benchmark_metadata\""
           },
           {
-            "name": "update_benchmarks",
-            "description": "update data of the table: \"benchmarks\"",
             "args": [
               {
                 "name": "_append",
-                "description": "append existing jsonb value of filtered columns with new jsonb value",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_append_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "append existing jsonb value of filtered columns with new jsonb value"
               },
               {
                 "name": "_delete_at_path",
-                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_at_path_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)"
               },
               {
                 "name": "_delete_elem",
-                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_elem_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array"
               },
               {
                 "name": "_delete_key",
-                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_key_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value"
               },
               {
                 "name": "_inc",
-                "description": "increments the integer columns with given value of the filtered values",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_inc_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "increments the integer columns with given value of the filtered values"
               },
               {
                 "name": "_prepend",
-                "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_prepend_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "prepend existing jsonb value of filtered columns with new jsonb value"
               },
               {
                 "name": "_set",
-                "description": "sets the columns of the filtered rows to the given values",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_set_input",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sets the columns of the filtered rows to the given values"
               },
               {
                 "name": "where",
-                "description": "filter the rows which have to be updated",
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_bool_exp",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows which have to be updated"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "update_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "update data of the table: \"benchmarks\""
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
-        "kind": "ENUM",
-        "name": "order_by",
-        "description": "column ordering options",
-        "fields": null,
         "inputFields": null,
+        "kind": "ENUM",
+        "possibleTypes": null,
         "interfaces": null,
+        "name": "order_by",
         "enumValues": [
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "asc",
-            "description": "in the ascending order, nulls last",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "in the ascending order, nulls last"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "asc_nulls_first",
-            "description": "in the ascending order, nulls first",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "in the ascending order, nulls first"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "asc_nulls_last",
-            "description": "in the ascending order, nulls last",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "in the ascending order, nulls last"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "desc",
-            "description": "in the descending order, nulls first",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "in the descending order, nulls first"
           },
           {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "desc_nulls_first",
-            "description": "in the descending order, nulls first",
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "description": "in the descending order, nulls first"
           },
           {
-            "name": "desc_nulls_last",
-            "description": "in the descending order, nulls last",
             "isDeprecated": false,
             "deprecationReason": null,
-            "__typename": "__EnumValue"
+            "name": "desc_nulls_last",
+            "description": "in the descending order, nulls last"
           }
         ],
-        "possibleTypes": null,
-        "__typename": "__Type"
+        "description": "column ordering options",
+        "fields": null
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "query_root",
+        "enumValues": null,
         "description": "query root",
         "fields": [
           {
-            "name": "benchmark_metadata",
-            "description": "fetch data from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8630,43 +7570,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8676,29 +7608,26 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8711,26 +7640,18 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch data from the table: \"benchmark_metadata\""
           },
           {
-            "name": "benchmark_metadata_aggregate",
-            "description": "fetch aggregated fields from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8740,43 +7661,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8786,83 +7699,69 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmark_metadata_aggregate",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch aggregated fields from the table: \"benchmark_metadata\""
           },
           {
-            "name": "benchmark_metadata_by_pk",
-            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns",
             "args": [
               {
                 "name": "id",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns"
           },
           {
-            "name": "benchmarks",
-            "description": "fetch data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8872,43 +7771,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8918,29 +7809,26 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmarks",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8953,26 +7841,18 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch data from the table: \"benchmarks\""
           },
           {
-            "name": "benchmarks_aggregate",
-            "description": "fetch aggregated fields from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -8982,43 +7862,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9028,63 +7900,53 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmarks_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarks_aggregate",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch aggregated fields from the table: \"benchmarks\""
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "OBJECT",
+        "possibleTypes": null,
+        "interfaces": [],
         "name": "subscription_root",
+        "enumValues": null,
         "description": "subscription root",
         "fields": [
           {
-            "name": "benchmark_metadata",
-            "description": "fetch data from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9094,43 +7956,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9140,29 +7994,26 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9175,26 +8026,18 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmark_metadata",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch data from the table: \"benchmark_metadata\""
           },
           {
-            "name": "benchmark_metadata_aggregate",
-            "description": "fetch aggregated fields from the table: \"benchmark_metadata\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9204,43 +8047,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmark_metadata_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9250,83 +8085,69 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmark_metadata_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmark_metadata_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmark_metadata_aggregate",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch aggregated fields from the table: \"benchmark_metadata\""
           },
           {
-            "name": "benchmark_metadata_by_pk",
-            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns",
             "args": [
               {
                 "name": "id",
-                "description": null,
+                "defaultValue": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                    "ofType": null
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": null
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmark_metadata_by_pk",
             "type": {
               "kind": "OBJECT",
               "name": "benchmark_metadata",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch data from the table: \"benchmark_metadata\" using primary key columns"
           },
           {
-            "name": "benchmarks",
-            "description": "fetch data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9336,43 +8157,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9382,29 +8195,26 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmarks",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9417,26 +8227,18 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null,
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                    "ofType": null
+                  }
+                }
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch data from the table: \"benchmarks\""
           },
           {
-            "name": "benchmarks_aggregate",
-            "description": "fetch aggregated fields from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "description": "distinct select on columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9446,43 +8248,35 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "distinct select on columns"
               },
               {
                 "name": "limit",
-                "description": "limit the number of rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "limit the number of rows returned"
               },
               {
                 "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
+                "defaultValue": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "skip the first n rows. Use only with order_by"
               },
               {
                 "name": "order_by",
-                "description": "sort the rows by one or more columns",
+                "defaultValue": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -9492,107 +8286,84 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null,
-                      "__typename": "__Type"
-                    },
-                    "__typename": "__Type"
-                  },
-                  "__typename": "__Type"
+                      "ofType": null
+                    }
+                  }
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "sort the rows by one or more columns"
               },
               {
                 "name": "where",
-                "description": "filter the rows returned",
+                "defaultValue": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null,
-                  "__typename": "__Type"
+                  "ofType": null
                 },
-                "defaultValue": null,
-                "__typename": "__InputValue"
+                "description": "filter the rows returned"
               }
             ],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "benchmarks_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarks_aggregate",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                "ofType": null
+              }
             },
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "__typename": "__Field"
+            "description": "fetch aggregated fields from the table: \"benchmarks\""
           }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null,
-        "__typename": "__Type"
+        ]
       },
       {
+        "inputFields": null,
         "kind": "SCALAR",
-        "name": "timestamp",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "timestamp",
+        "enumValues": null,
+        "description": null,
+        "fields": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "timestamp_comparison_exp",
-        "description": "expression to compare columns of type timestamp. All fields are combined with logical 'AND'.",
-        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_gte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_in",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -9602,67 +8373,55 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "timestamp",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_is_null",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lt",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_lte",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_neq",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null,
-              "__typename": "__Type"
+              "ofType": null
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           },
           {
             "name": "_nin",
-            "description": null,
+            "defaultValue": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -9672,83 +8431,24 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "timestamp",
-                  "ofType": null,
-                  "__typename": "__Type"
-                },
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
+                  "ofType": null
+                }
+              }
             },
-            "defaultValue": null,
-            "__typename": "__InputValue"
+            "description": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
+        "kind": "INPUT_OBJECT",
         "possibleTypes": null,
-        "__typename": "__Type"
+        "interfaces": null,
+        "name": "timestamp_comparison_exp",
+        "enumValues": null,
+        "description": "expression to compare columns of type timestamp. All fields are combined with logical 'AND'.",
+        "fields": null
       }
     ],
-    "directives": [
-      {
-        "name": "include",
-        "description": null,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
-        "args": [
-          {
-            "name": "if",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "__typename": "__Directive"
-      },
-      {
-        "name": "skip",
-        "description": null,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
-        "args": [
-          {
-            "name": "if",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null,
-                "__typename": "__Type"
-              },
-              "__typename": "__Type"
-            },
-            "defaultValue": null,
-            "__typename": "__InputValue"
-          }
-        ],
-        "__typename": "__Directive"
-      }
-    ],
-    "__typename": "__Schema"
+    "mutationType": {
+      "name": "mutation_root"
+    }
   }
 }

--- a/hasura-server/metadata/tables.yaml
+++ b/hasura-server/metadata/tables.yaml
@@ -35,5 +35,7 @@
       - build_job_id
       - run_job_id
       - failed
+      - cancelled
+      - cancel_reason
       - pr_title
       filter: {}

--- a/pipeline/db/migrations/20211203103916_benchmark_metadata_cancelled_reason_columns.down.sql
+++ b/pipeline/db/migrations/20211203103916_benchmark_metadata_cancelled_reason_columns.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE benchmark_metadata
+    DROP COLUMN cancelled,
+    DROP COLUMN cancel_reason;

--- a/pipeline/db/migrations/20211203103916_benchmark_metadata_cancelled_reason_columns.up.sql
+++ b/pipeline/db/migrations/20211203103916_benchmark_metadata_cancelled_reason_columns.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE benchmark_metadata
+    ADD cancelled boolean DEFAULT FALSE,
+    ADD cancel_reason TEXT;


### PR DESCRIPTION
The PR adds new columns to indicate cancelled builds (and the reason) in benchmarks_metadata table. It also updates the UI to display cancelled build status correctly.  

The PR doesn't yet update the GitHub status about cancelled builds. When a PR is merged while the benchmarks are running, the status of the check would end-up staying as running in the GitHub UI, instead of saying something like cancelled. This may be alright for now, but would be nice to fix. I'll try to work on this as a follow-up to this PR, if it makes sense to do so. 

Thanks to @gs0510 and @art-w for helping me with ideas on how to go about working on this PR. 

![image](https://user-images.githubusercontent.com/315678/144597555-fa78ce1a-a4f2-4d57-8dc9-6ba3c9e6aa10.png)
