### PR TITLE
Improve how we adjust units for size metrics

### DIFF
--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -1,9 +1,9 @@
+let sizeUnits = ["bytes", "kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"]
 // FIXME: Should include other units too?!
 let sizeRegex = %re("/(gb|mb|kb|bytes)\w*/i")
 let isSize = x => Js.Re.exec_(sizeRegex, x)->Belt.Option.isSome
 
 let formatSize = (value, units) => {
-  let unitArr = ["bytes", "kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"]
   let exp = Js.Math.log10(value)->Js.Math.floor_int
   let unitChange = exp / 3
   let changeFactor = Js.Math.pow_float(~base=10.0, ~exp=(unitChange * 3)->Js.Int.toFloat)
@@ -15,9 +15,8 @@ let formatSize = (value, units) => {
 
   let reMatch = Js.Re.exec_(sizeRegex, units)
   let oldStr = reMatch->Belt.Option.getExn->Js.Re.captures->Belt.Array.getExn(1)->Js.String.make
-  // unitArrIndex <- index of the regex match in unitArr
-  let unitArrIndex = Js.Array.findIndex(x => x == oldStr, unitArr)
-  let newStr = Belt.Array.getExn(unitArr, unitArrIndex + unitChange)
+  let unitIndex = Js.Array.findIndex(x => x == oldStr, sizeUnits)
+  let newStr = Belt.Array.getExn(sizeUnits, unitIndex + unitChange)
   let newUnit = Js.String.replace(oldStr, newStr, units)
   (newValue, newUnit)
 }

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -1,4 +1,6 @@
-let isSize = x => Js.Re.exec_(%re("/(gb|mb|kb|bytes)\w*/i"), x)->Belt.Option.isSome
+// FIXME: Should include other units too?!
+let sizeRegex = %re("/(gb|mb|kb|bytes)\w*/i")
+let isSize = x => Js.Re.exec_(sizeRegex, x)->Belt.Option.isSome
 
 let formatSize = (value, units) => {
   let unitArr = ["bytes", "kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"]
@@ -11,7 +13,7 @@ let formatSize = (value, units) => {
     ->Belt.Float.fromString
     ->Belt.Option.getExn
 
-  let reMatch = Js.Re.exec_(%re("/(gb|mb|kb|bytes)\w*/i"), units)
+  let reMatch = Js.Re.exec_(sizeRegex, units)
   let oldStr = reMatch->Belt.Option.getExn->Js.Re.captures->Belt.Array.getExn(1)->Js.String.make
   // unitArrIndex <- index of the regex match in unitArr
   let unitArrIndex = Js.Array.findIndex(x => x == oldStr, unitArr)

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -9,21 +9,33 @@ let getUnitsIndex = units => {
   Js.Array.findIndex(x => x == oldStr, sizeUnits)
 }
 
-let formatSize = (value, units) => {
-  let exp = Js.Math.log10(value)->Js.Math.floor_int
-  let unitChange = exp / 3
+let getAdjustedSize = (value, units, unitIndex, unitChange) => {
   let changeFactor = Js.Math.pow_float(~base=10.0, ~exp=(unitChange * 3)->Js.Int.toFloat)
   let newValue =
     (value /. changeFactor)
     ->Js.Float.toFixedWithPrecision(~digits=2)
     ->Belt.Float.fromString
     ->Belt.Option.getExn
-  let unitIndex = getUnitsIndex(units)
   let newUnitIndex = unitIndex + unitChange
   let oldStr = Belt.Array.getExn(sizeUnits, unitIndex)
   let newStr = Belt.Array.getExn(sizeUnits, newUnitIndex)
   let newUnit = Js.String.replace(oldStr, newStr, units)
   (newValue, newUnit)
+}
+
+let formatSize = (value, units) => {
+  let exp = Js.Math.log10(value)->Js.Math.floor_int
+  let unitChange = exp / 3
+  let unitIndex = getUnitsIndex(units)
+  getAdjustedSize(value, units, unitIndex, unitChange)
+}
+
+let changeSizeUnits = (value, units, newUnits) => {
+  let oldUnitIndex = getUnitsIndex(units)
+  let newUnitIndex = getUnitsIndex(newUnits)
+  let unitChange = newUnitIndex - oldUnitIndex
+  let (value_, _) = getAdjustedSize(value, units, oldUnitIndex, unitChange)
+  value_
 }
 
 let format = (value, units) => {

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -3,6 +3,12 @@ let sizeUnits = ["bytes", "kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"]
 let sizeRegex = %re("/(gb|mb|kb|bytes)\w*/i")
 let isSize = x => Js.Re.exec_(sizeRegex, x)->Belt.Option.isSome
 
+let getUnitsIndex = units => {
+  let reMatch = Js.Re.exec_(sizeRegex, units)
+  let oldStr = reMatch->Belt.Option.getExn->Js.Re.captures->Belt.Array.getExn(1)->Js.String.make
+  Js.Array.findIndex(x => x == oldStr, sizeUnits)
+}
+
 let formatSize = (value, units) => {
   let exp = Js.Math.log10(value)->Js.Math.floor_int
   let unitChange = exp / 3
@@ -12,11 +18,10 @@ let formatSize = (value, units) => {
     ->Js.Float.toFixedWithPrecision(~digits=2)
     ->Belt.Float.fromString
     ->Belt.Option.getExn
-
-  let reMatch = Js.Re.exec_(sizeRegex, units)
-  let oldStr = reMatch->Belt.Option.getExn->Js.Re.captures->Belt.Array.getExn(1)->Js.String.make
-  let unitIndex = Js.Array.findIndex(x => x == oldStr, sizeUnits)
-  let newStr = Belt.Array.getExn(sizeUnits, unitIndex + unitChange)
+  let unitIndex = getUnitsIndex(units)
+  let newUnitIndex = unitIndex + unitChange
+  let oldStr = Belt.Array.getExn(sizeUnits, unitIndex)
+  let newStr = Belt.Array.getExn(sizeUnits, newUnitIndex)
   let newUnit = Js.String.replace(oldStr, newStr, units)
   (newValue, newUnit)
 }

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -12,16 +12,7 @@ let formatSize = (value, units) => {
     ->Belt.Option.getExn
 
   let reMatch = Js.Re.exec_(%re("/(gb|mb|kb|bytes)\w*/i"), units)
-  let startIndex = reMatch->Belt.Option.getExn->Js.Re.index
-  let endIndex =
-    startIndex +
-    reMatch
-    ->Belt.Option.getExn
-    ->Js.Re.captures
-    ->Belt.Array.getExn(1)
-    ->Js.String.make
-    ->Js.String.length
-  let oldStr = Js.String.substring(~from=startIndex, ~to_=endIndex, units)
+  let oldStr = reMatch->Belt.Option.getExn->Js.Re.captures->Belt.Array.getExn(1)->Js.String.make
   // unitArrIndex <- index of the regex match in unitArr
   let unitArrIndex = Js.Array.findIndex(x => x == oldStr, unitArr)
   let newStr = Belt.Array.getExn(unitArr, unitArrIndex + unitChange)

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -1,50 +1,44 @@
-let isSize = (x) => Js.Re.exec_(%re("/(gb|mb|kb|bytes)\w*/i"), x)
-  ->Belt.Option.isSome
+let isSize = x => Js.Re.exec_(%re("/(gb|mb|kb|bytes)\w*/i"), x)->Belt.Option.isSome
 
 let formatSize = (value, units) => {
   let unitArr = ["bytes", "kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"]
   // exp_ is the exponent value derived from value
   // exp tracks the unit change (which is a factor of 3)
   // mod_exp is the value tracking exp_ % 3 which is multiplied to fractional part
-  let exp_ = Js.Math.log10(value)
-    ->Js.Math.floor_int
-  let exp  = exp_ / 3
+  let exp_ = Js.Math.log10(value)->Js.Math.floor_int
+  let exp = exp_ / 3
   let mod_exp = mod(exp_, 3)->Belt.Int.toFloat
-  let newValue = Js.Math.pow_float(
-    ~base=10.0,
-    ~exp=(Js.Math.log10(value) -. Js.Int.toFloat(exp_))
-  )
-  ->(x => x *. (Js.Math.pow_float(~base=10.0, ~exp=mod_exp)))
-  ->Js.Float.toFixedWithPrecision(~digits=2)
-  ->Belt.Float.fromString
-  ->Belt.Option.getExn
+  let newValue =
+    Js.Math.pow_float(~base=10.0, ~exp=Js.Math.log10(value) -. Js.Int.toFloat(exp_))
+    ->(x => x *. Js.Math.pow_float(~base=10.0, ~exp=mod_exp))
+    ->Js.Float.toFixedWithPrecision(~digits=2)
+    ->Belt.Float.fromString
+    ->Belt.Option.getExn
 
   let reMatch = Js.Re.exec_(%re("/(gb|mb|kb|bytes)\w*/i"), units)
-  let startIndex = reMatch
-    ->Belt.Option.getExn
-    ->Js.Re.index
-  let endIndex = startIndex + 
-    (reMatch
+  let startIndex = reMatch->Belt.Option.getExn->Js.Re.index
+  let endIndex =
+    startIndex +
+    reMatch
     ->Belt.Option.getExn
     ->Js.Re.captures
     ->Belt.Array.getExn(1)
     ->Js.String.make
-    ->Js.String.length)
+    ->Js.String.length
   let oldStr = Js.String.substring(~from=startIndex, ~to_=endIndex, units)
   // unitArrIndex <- index of the regex match in unitArr
   let unitArrIndex = Js.Array.findIndex(x => x == oldStr, unitArr)
   let newStr = Belt.Array.getExn(unitArr, unitArrIndex + exp)
-  let newUnit = Js.String.replace(oldStr, newStr, units) 
+  let newUnit = Js.String.replace(oldStr, newStr, units)
 
   (newValue, newUnit)
 }
 
 let format = (value, units) => {
   switch value {
-    | Current_bench_json.Latest.Float(value) if isSize(units) =>
-        let (value, units) = formatSize(value, units)
-        (Current_bench_json.Latest.Float(value), units)
-    | _ =>
-        (value, units)
+  | Current_bench_json.Latest.Float(value) if isSize(units) =>
+    let (value, units) = formatSize(value, units)
+    (Current_bench_json.Latest.Float(value), units)
+  | _ => (value, units)
   }
 }

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -76,7 +76,6 @@ module Benchmark = {
     ->Belt.Array.reduce(BenchmarkData.empty, (acc, (commit, run_at, test_index, item)) => {
       List.fold_left((acc, result: Current_bench_json.Latest.result) => {
         List.fold_left((acc, metric: Current_bench_json.Latest.metric) => {
-          let (value, units) = AdjustMetricUnit.format(metric.value, metric.units)
           BenchmarkData.add(
             acc,
             ~testName=result.test_name,
@@ -84,17 +83,18 @@ module Benchmark = {
             ~metricName=metric.name,
             ~runAt=run_at,
             ~commit,
-            ~value=toLineGraph(value),
-            ~units,
+            ~value=toLineGraph(metric.value),
+            ~units=metric.units,
           )
         }, acc, result.metrics)
       }, acc, item.results)
     })
   }
+
   @react.component
   let make = React.memo((~repoId, ~pullNumber, ~data: GetBenchmarks.t, ~oldMetrics=false) => {
     let benchmarkDataByTestName = React.useMemo2(() => {
-      data.benchmarks->makeBenchmarkData
+      data.benchmarks->makeBenchmarkData->AdjustMetricUnit.adjust
     }, (data.benchmarks, makeBenchmarkData))
     let comparisonBenchmarkDataByTestName = React.useMemo2(
       () => data.comparisonBenchmarks->Belt.Array.reverse->makeBenchmarkData,

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -37,32 +37,36 @@ let makeGetBenchmarksVariables = (
 module Benchmark = {
   let decodeRunAt = runAt => runAt->Js.Json.decodeString->Belt.Option.map(Js.Date.fromString)
 
-  let yojson_of_result = (result : BenchmarkMetrics.t) => {
+  let yojson_of_result = (result: BenchmarkMetrics.t) => {
     let metrics = DataHelpers.yojson_of_json(result.metrics->Belt.Option.getExn)
-    #Assoc(list{("version", #Int(result.version)),
-                ("results", #List(list{#Assoc(list{("name", #String(result.test_name)),
-                                                   ("metrics", metrics)})}))})
+    #Assoc(list{
+      ("version", #Int(result.version)),
+      (
+        "results",
+        #List(list{#Assoc(list{("name", #String(result.test_name)), ("metrics", metrics)})}),
+      ),
+    })
   }
 
-  let decode = (result : BenchmarkMetrics.t) => {
+  let decode = (result: BenchmarkMetrics.t) => {
     let metrics = yojson_of_result(result)
     let metrics = Current_bench_json.of_json(metrics)
     let run_at = result.run_at->decodeRunAt->Belt.Option.getExn
     (result.commit, run_at, result.test_index, metrics)
   }
 
-  let tryDecode = (result) => {
+  let tryDecode = result => {
     try {
       Some(decode(result))
     } catch {
-      | _ => None
+    | _ => None
     }
   }
 
-  let toLineGraph = (value : Current_bench_json.Latest.value) => {
+  let toLineGraph = (value: Current_bench_json.Latest.value) => {
     switch value {
-      | Float(x) => LineGraph.DataRow.single(x)
-      | Floats(xs) => LineGraph.DataRow.many(Array.of_list(xs))
+    | Float(x) => LineGraph.DataRow.single(x)
+    | Floats(xs) => LineGraph.DataRow.many(Array.of_list(xs))
     }
   }
 
@@ -70,21 +74,21 @@ module Benchmark = {
     benchmarks
     ->Belt.Array.keepMap(tryDecode)
     ->Belt.Array.reduce(BenchmarkData.empty, (acc, (commit, run_at, test_index, item)) => {
-        ->List.fold_left((acc, (result : Current_bench_json.Latest.result) ) => {
-            List.fold_left((acc, (metric : Current_bench_json.Latest.metric)) => {
-              let (value, units) = AdjustMetricUnit.format(metric.value, metric.units)
-              BenchmarkData.add(
-                acc,
-                ~testName=result.test_name,
-                ~testIndex=test_index,
-                ~metricName=metric.name,
-                ~runAt=run_at,
-                ~commit=commit,
-                ~value=toLineGraph(value),
-                ~units=units,
-              )
-            }, acc, result.metrics)
-        }, acc, item.results)
+      List.fold_left((acc, result: Current_bench_json.Latest.result) => {
+        List.fold_left((acc, metric: Current_bench_json.Latest.metric) => {
+          let (value, units) = AdjustMetricUnit.format(metric.value, metric.units)
+          BenchmarkData.add(
+            acc,
+            ~testName=result.test_name,
+            ~testIndex=test_index,
+            ~metricName=metric.name,
+            ~runAt=run_at,
+            ~commit,
+            ~value=toLineGraph(value),
+            ~units,
+          )
+        }, acc, result.metrics)
+      }, acc, item.results)
     })
   }
   @react.component


### PR DESCRIPTION
Previously, we adjusted the sizes for each of the observations separately and
this would cause the graph to be meaningless some times, when different values
in a timeseries get adjusted by different exponents.

This can happen when different values in the time series are on different sides
of any 10^3 value -- for instance, 999 mbps and 1001 mbps would get adjusted to
999 mbps and 1.001 gbps. But, the values plotted in the graph would be 999 and
1.001 making the graph seem meaningless.