### PR TITLE
Display min and max values when displaying multi-value datapoints 

### DIFF
--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -1,12 +1,6 @@
 open! Prelude
 open Components
 
-type testMetrics = {
-  name: string,
-  commit: string,
-  metrics: array<LineGraph.DataRow.metric>,
-}
-
 @module("../icons/branch.svg") external branchIcon: string = "default"
 
 let calcDelta = (a, b) => {

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -159,10 +159,14 @@ module Legend = {
     switch xLabel {
     | Some(xLabel) =>
       let html = "<b>" ++ xLabel ++ "</b>"
-      let legend = Array.map((unit: t) => {
+      let row = (dashHTML, labelHTML, yHTML) => {
         "<div class='dygraph-legend-row'>" ++
-        (unit.dashHTML ++
-        ("<div>" ++ " <b>" ++ unit.yHTML ++ "</b>" ++ "</div>" ++ "</div>"))
+        (dashHTML ++
+        ("<div>" ++ labelHTML ++ "&ndash; </div>") ++
+        ("<div>" ++ " <b>" ++ yHTML ++ "</b>" ++ "</div>" ++ "</div>"))
+      }
+      let legend = Array.map((unit: t) => {
+        row(unit.dashHTML, unit.labelHTML, unit.yHTML)
       }, data.series)
       let legend = Array.fold_left((a, b) => a ++ b, "", legend)
       `<div class="dygraph-legend-formatter">${html}${legend}</div>`

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -211,7 +211,7 @@ let defaultOptions = (
       },
     },
     "series": {
-      "std-dev": {
+      "mean": {
         "strokeWidth": 1.0,
         "strokePattern": [3, 2],
         "highlightCircleSize": 0,
@@ -318,7 +318,7 @@ let make = React.memo((
   }
   let data = addSeries(data, constantSeries)
   let labels = labels->Belt.Option.map(labels => {
-    labels->BeltHelpers.Array.add("std-dev")
+    labels->BeltHelpers.Array.add("mean")
   })
 
   // Dygraph does not display the last tick, so a dummy value

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -142,6 +142,7 @@ let getElementHTMLonClick: (Dom.element, string => unit) => unit = %raw(`
 
 module Legend = {
   type t = {
+    label: string,
     labelHTML: string,
     yHTML: string,
     dashHTML: string,
@@ -165,8 +166,13 @@ module Legend = {
         ("<div>" ++ labelHTML ++ "&ndash; </div>") ++
         ("<div>" ++ " <b>" ++ yHTML ++ "</b>" ++ "</div>" ++ "</div>"))
       }
-      let legend = Array.map((unit: t) => {
-        row(unit.dashHTML, unit.labelHTML, unit.yHTML)
+      let legend = Array.mapi((idx, unit: t) => {
+        // Add extra header for overall stats
+        let extraHeader = switch unit.label {
+        | "mean" => "<b>Overall Stats</b>"
+        | _ => ""
+        }
+        extraHeader ++ row(unit.dashHTML, unit.labelHTML, unit.yHTML)
       }, data.series)
       let legend = Array.fold_left((a, b) => a ++ b, "", legend)
       `<div class="dygraph-legend-formatter">${html}${legend}</div>`

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -158,11 +158,11 @@ module Legend = {
     }
     switch xLabel {
     | Some(xLabel) =>
-      let html = "<b>" ++ (xLabel ++ "</b>")
+      let html = "<b>" ++ xLabel ++ "</b>"
       let legend = Array.map((unit: t) => {
         "<div class='dygraph-legend-row'>" ++
         (unit.dashHTML ++
-        ("<div>" ++ (" <b>" ++ (unit.yHTML ++ ("</b>" ++ ("</div>" ++ "</div>"))))))
+        ("<div>" ++ " <b>" ++ unit.yHTML ++ "</b>" ++ "</div>" ++ "</div>"))
       }, data.series)
       let legend = Array.fold_left((a, b) => a ++ b, "", legend)
       `<div class="dygraph-legend-formatter">${html}${legend}</div>`


### PR DESCRIPTION
Non multi-value data points
![image](https://user-images.githubusercontent.com/315678/145419546-a7b260a9-8224-4de5-b752-88c3ff282508.png)

Multi-value datapoints
![image](https://user-images.githubusercontent.com/315678/145419672-31054f4d-226b-4b27-8939-0beec05b4d78.png)

We were previously also showing the overall average for the time series. This PR also displays overall min and max and makes the legend a little clearer separating the overall stats with a header.