### PR TITLE
Workers: run one benchmark per cpu

### DIFF
--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -121,7 +121,6 @@ services:
       - "--state-dir=/app/state"
       - "--ocluster-pool=./capnp-secrets/pool-linux.cap"
       - "--docker-cpu=${OCAML_BENCH_DOCKER_CPU?required}"
-      - "--multicore-repositories=${OCAML_BENCH_MULTICORE_REPOSITORIES}"
     volumes:
       - ../capnp-secrets:/app/capnp-secrets
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This PR allows workers to run multiple benchmarks at the same time, each using a distinct CPU.

You need to check that the `.env` contains a comma separated list and not a range:

```
OCAML_BENCH_DOCKER_CPU=4,5,6
```