### PR TITLE
Cut down the usage of Obj.magic in the UI code

### DIFF
--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -42,12 +42,10 @@ let adjustSize = (timeseries: BenchmarkData.timeseries, units: LineGraph.DataRow
   let avgs = Belt.Array.map(timeseries, LineGraph.DataRow.toFloat)
   let maxValue = Array.fold_left((a, b) => a < b ? b : a, 0., avgs)
   let (_, newUnits) = formatSize(maxValue, units)
-  let adjustedTimeseries = Belt.Array.map(timeseries, valueWithTime => {
-    let (time, value) = Obj.magic(valueWithTime)
-    let adjustedValues = Belt.Array.map(value, v =>
+  let adjustedTimeseries = Belt.Array.map(timeseries, value => {
+    Belt.Array.map(value, v =>
       v == LineGraph.DataRow.floatNull ? v : changeSizeUnits(v, units, newUnits)
     )
-    Obj.magic([time, adjustedValues])
   })
   (adjustedTimeseries, newUnits)
 }

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -39,7 +39,7 @@ let changeSizeUnits = (value, units, newUnits) => {
 }
 
 let adjustSize = (timeseries: BenchmarkData.timeseries, units: LineGraph.DataRow.units) => {
-  let avgs = Belt.Array.map(timeseries, val => Obj.magic(val[1])[1])
+  let avgs = Belt.Array.map(timeseries, LineGraph.DataRow.toFloat)
   let maxValue = Array.fold_left((a, b) => a < b ? b : a, 0., avgs)
   let (_, newUnits) = formatSize(maxValue, units)
   let adjustedTimeseries = Belt.Array.map(timeseries, valueWithTime => {

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -39,7 +39,7 @@ let changeSizeUnits = (value, units, newUnits) => {
 }
 
 let adjustSize = (timeseries: BenchmarkData.timeseries, units: LineGraph.DataRow.units) => {
-  let avgs = Belt.Array.map(timeseries, LineGraph.DataRow.toFloat)
+  let avgs = Belt.Array.map(timeseries, LineGraph.DataRow.toValue)
   let maxValue = Array.fold_left((a, b) => a < b ? b : a, 0., avgs)
   let (_, newUnits) = formatSize(maxValue, units)
   let adjustedTimeseries = Belt.Array.map(timeseries, value => {

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -45,7 +45,7 @@ let adjustSize = (timeseries: BenchmarkData.timeseries, units: LineGraph.DataRow
   let adjustedTimeseries = Belt.Array.map(timeseries, valueWithTime => {
     let (time, value) = Obj.magic(valueWithTime)
     let adjustedValues = Belt.Array.map(value, v =>
-      Obj.magic(v) == Js.null ? v : changeSizeUnits(v, units, newUnits)
+      v == LineGraph.DataRow.floatNull ? v : changeSizeUnits(v, units, newUnits)
     )
     Obj.magic([time, adjustedValues])
   })

--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -43,9 +43,7 @@ let adjustSize = (timeseries: BenchmarkData.timeseries, units: LineGraph.DataRow
   let maxValue = Array.fold_left((a, b) => a < b ? b : a, 0., avgs)
   let (_, newUnits) = formatSize(maxValue, units)
   let adjustedTimeseries = Belt.Array.map(timeseries, value => {
-    Belt.Array.map(value, v =>
-      v == LineGraph.DataRow.floatNull ? v : changeSizeUnits(v, units, newUnits)
-    )
+    Belt.Array.map(value, v => Js.Float.isNaN(v) ? v : changeSizeUnits(v, units, newUnits))
   })
   (adjustedTimeseries, newUnits)
 }

--- a/frontend/src/BenchmarkData.res
+++ b/frontend/src/BenchmarkData.res
@@ -1,13 +1,13 @@
 open Belt
 
-type timeseries = array<LineGraph.DataRow.t>
+type timeseries = array<LineGraph.DataRow.row>
 type byMetricName = Map.String.t<(
   timeseries,
   array<{
     "commit": string,
     "runAt": Js.Date.t,
     "units": LineGraph.DataRow.units,
-    "description": string
+    "description": string,
   }>,
 )>
 type byTestName = Map.String.t<(int, byMetricName)>
@@ -22,7 +22,7 @@ let add = (
   ~metricName,
   ~runAt: Js.Date.t,
   ~commit,
-  ~value: LineGraph.DataRow.value,
+  ~value: LineGraph.DataRow.t,
   ~units: LineGraph.DataRow.units,
   ~description,
 ) => {
@@ -31,7 +31,10 @@ let add = (
   let (timeseries, metadata) = Map.String.getWithDefault(byMetricName, metricName, ([], []))
 
   // Update
-  let timeseries = BeltHelpers.Array.add(timeseries, [Obj.magic(Belt.Array.length(timeseries)), value])
+  let timeseries = BeltHelpers.Array.add(
+    timeseries,
+    [Obj.magic(Belt.Array.length(timeseries)), value],
+  )
   let metadata = BeltHelpers.Array.add(
     metadata,
     {"commit": commit, "runAt": runAt, "units": units, "description": description},

--- a/frontend/src/BenchmarkData.res
+++ b/frontend/src/BenchmarkData.res
@@ -31,8 +31,7 @@ let add = (
   let (timeseries, metadata) = Map.String.getWithDefault(byMetricName, metricName, ([], []))
 
   // Update
-  let row = LineGraph.DataRow.with_date(runAt, value)
-  let timeseries = BeltHelpers.Array.add(timeseries, row)
+  let timeseries = BeltHelpers.Array.add(timeseries, [Obj.magic(Belt.Array.length(timeseries)), value])
   let metadata = BeltHelpers.Array.add(
     metadata,
     {"commit": commit, "runAt": runAt, "units": units, "description": description},

--- a/frontend/src/BenchmarkData.res
+++ b/frontend/src/BenchmarkData.res
@@ -1,6 +1,6 @@
 open Belt
 
-type timeseries = array<LineGraph.DataRow.row>
+type timeseries = array<LineGraph.DataRow.t>
 type byMetricName = Map.String.t<(
   timeseries,
   array<{
@@ -31,10 +31,7 @@ let add = (
   let (timeseries, metadata) = Map.String.getWithDefault(byMetricName, metricName, ([], []))
 
   // Update
-  let timeseries = BeltHelpers.Array.add(
-    timeseries,
-    [Obj.magic(Belt.Array.length(timeseries)), value],
-  )
+  let timeseries = BeltHelpers.Array.add(timeseries, value)
   let metadata = BeltHelpers.Array.add(
     metadata,
     {"commit": commit, "runAt": runAt, "units": units, "description": description},

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -31,8 +31,8 @@ let renderMetricOverviewRow = (
   } else {
     let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toFloat
     let (vsMasterAbs, vsMasterRel) = switch BeltHelpers.Array.last(comparisonTimeseries) {
-    | Some(lastComparisionRow) =>
-      let lastComparisonY = lastComparisionRow->LineGraph.DataRow.toFloat
+    | Some(lastComparisonRow) =>
+      let lastComparisonY = lastComparisonRow->LineGraph.DataRow.toFloat
       (
         Js.Float.toPrecisionWithPrecision(~digits=6)(lastComparisonY),
         calcDelta(last_value, lastComparisonY)->deltaToString,
@@ -63,8 +63,8 @@ let getMetricDelta = (
     let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toFloat
 
     switch BeltHelpers.Array.last(comparisonTimeseries) {
-    | Some(lastComparisionRow) =>
-      let lastComparisonY = lastComparisionRow->LineGraph.DataRow.toFloat
+    | Some(lastComparisonRow) =>
+      let lastComparisonY = lastComparisonRow->LineGraph.DataRow.toFloat
       Some(calcDelta(last_value, lastComparisonY))
     | _ => None
     }

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -21,7 +21,7 @@ let deltaToString = n =>
   }
 
 let renderMetricOverviewRow = (
-  ~comparison as (comparisonTimeseries: array<LineGraph.DataRow.t>, _comparisonMetadata)=([], []),
+  ~comparison as (comparisonTimeseries: array<LineGraph.DataRow.row>, _comparisonMetadata)=([], []),
   ~testName,
   ~metricName,
   (timeseries, _),
@@ -77,7 +77,7 @@ let make = (
   ~pullNumber,
   ~testName,
   ~comparison=Belt.Map.String.empty,
-  ~dataByMetricName: Belt.Map.String.t<(array<LineGraph.DataRow.t>, 'a)>,
+  ~dataByMetricName: Belt.Map.String.t<(array<LineGraph.DataRow.row>, 'a)>,
 ) => {
   let metric_table = {
     <Table sx=[Sx.mb.xl2]>
@@ -118,7 +118,7 @@ let make = (
         ([], []),
       )
 
-      let timeseries: array<LineGraph.DataRow.t> = Belt.Array.concat(
+      let timeseries: array<LineGraph.DataRow.row> = Belt.Array.concat(
         comparisonTimeseries,
         timeseries,
       )

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -29,10 +29,10 @@ let renderMetricOverviewRow = (
   if Belt.Array.length(timeseries) == 0 {
     React.null
   } else {
-    let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toFloat
+    let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toValue
     let (vsMasterAbs, vsMasterRel) = switch BeltHelpers.Array.last(comparisonTimeseries) {
     | Some(lastComparisonRow) =>
-      let lastComparisonY = lastComparisonRow->LineGraph.DataRow.toFloat
+      let lastComparisonY = lastComparisonRow->LineGraph.DataRow.toValue
       (
         Js.Float.toPrecisionWithPrecision(~digits=6)(lastComparisonY),
         calcDelta(last_value, lastComparisonY)->deltaToString,
@@ -60,11 +60,11 @@ let getMetricDelta = (
   if Belt.Array.length(timeseries) == 0 {
     None
   } else {
-    let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toFloat
+    let last_value = BeltHelpers.Array.lastExn(timeseries)->LineGraph.DataRow.toValue
 
     switch BeltHelpers.Array.last(comparisonTimeseries) {
     | Some(lastComparisonRow) =>
-      let lastComparisonY = lastComparisonRow->LineGraph.DataRow.toFloat
+      let lastComparisonY = lastComparisonRow->LineGraph.DataRow.toValue
       Some(calcDelta(last_value, lastComparisonY))
     | _ => None
     }

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -21,7 +21,7 @@ let deltaToString = n =>
   }
 
 let renderMetricOverviewRow = (
-  ~comparison as (comparisonTimeseries: array<LineGraph.DataRow.row>, _comparisonMetadata)=([], []),
+  ~comparison as (comparisonTimeseries: array<LineGraph.DataRow.t>, _comparisonMetadata)=([], []),
   ~testName,
   ~metricName,
   (timeseries, _),
@@ -77,7 +77,7 @@ let make = (
   ~pullNumber,
   ~testName,
   ~comparison=Belt.Map.String.empty,
-  ~dataByMetricName: Belt.Map.String.t<(array<LineGraph.DataRow.row>, 'a)>,
+  ~dataByMetricName: Belt.Map.String.t<(array<LineGraph.DataRow.t>, 'a)>,
 ) => {
   let metric_table = {
     <Table sx=[Sx.mb.xl2]>
@@ -118,15 +118,13 @@ let make = (
         ([], []),
       )
 
-      let timeseries: array<LineGraph.DataRow.row> = Belt.Array.concat(
+      let timeseries: array<LineGraph.DataRow.t> = Belt.Array.concat(
         comparisonTimeseries,
         timeseries,
       )
       let metadata = Belt.Array.concat(comparisonMetadata, metadata)
 
-      let xTicks = Belt.Array.reduceWithIndex(timeseries, Belt.Map.Int.empty, (acc, row, index) => {
-        // Use indexed instead of dates. This allows us to map to commits.
-        LineGraph.DataRow.set_index(index, row)
+      let xTicks = Belt.Array.reduceWithIndex(timeseries, Belt.Map.Int.empty, (acc, _, index) => {
         let tick = switch Belt.Array.get(metadata, index) {
         | Some(xMetadata) =>
           let xValue = xMetadata["commit"]

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -68,8 +68,6 @@ module DataRow = {
     Obj.magic([Obj.magic(low), Obj.magic(mid), Obj.magic(high)])
   }
 
-  let with_date = (date: Js.Date.t, value): t => [Obj.magic(date), value]
-
   let set_index = (index: int, row: t): unit => {
     let index: value = Obj.magic(index)
     Belt.Array.set(row, 0, index)->ignore

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -72,7 +72,7 @@ module DataRow = {
 
   let dummyValue = [floatNull, nan, floatNull]
 
-  let toFloat = (row: t): float => row[1]
+  let toValue = (row: t): value => row[1]
 }
 
 @new @module("dygraphs")
@@ -300,7 +300,7 @@ let make = React.memo((
 
   // Add constant stdDev series.
   let constantSeries = {
-    let values = data->Belt.Array.map(DataRow.toFloat)
+    let values = data->Belt.Array.map(DataRow.toValue)
     let mean = values->computeMean->Belt.Option.getWithDefault(0.0)
     let stdDev = computeStdDev(~mean, values)
     DataRow.valueWithErrorBars(~mid=mean, ~low=mean -. stdDev, ~high=mean +. stdDev)
@@ -407,7 +407,7 @@ let make = React.memo((
   let right =
     <Row alignX=#right spacing=Sx.md sx=[Sx.w.auto]>
       <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray900)]>
-        {lastValue->DataRow.toFloat->Js.Float.toPrecisionWithPrecision(~digits=4)}
+        {lastValue->DataRow.toValue->Js.Float.toPrecisionWithPrecision(~digits=4)}
       </Text>
       <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray500)]> units </Text>
     </Row>

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -51,7 +51,7 @@ module DataRow = {
   type name = string
   type units = string
   type value
-  type metric = {name, value, units}
+  type metric = {name: name, value: value, units: units}
   type t = array<value>
 
   let single = (x: float): value =>
@@ -453,7 +453,7 @@ let make = React.memo((
           Js.Float.toPrecisionWithPrecision(~digits=4, DataRow.toFloat(value))
         )}
       </Text>
-      <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray500)]>units</Text>
+      <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray500)]> units </Text>
     </Row>
 
   let sx = Array.append(uSx, containerSx)

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -79,12 +79,6 @@ module DataRow = {
     Obj.magic(row[0])
   }
 
-  let nan = (~index): t => [
-    Obj.magic(index),
-    Obj.magic([Obj.magic(Js.null), nan, Obj.magic(Js.null)]),
-  ]
-
-  // Similar to nan, but with for two series.
   let nan2 = (~index): t => [
     Obj.magic(index),
     Obj.magic([Obj.magic(Js.null), nan, Obj.magic(Js.null)]),


### PR DESCRIPTION
The type LineGraph.DataRow.value is used ubiquitously and often with a lot of Obj.magic wrappers. This makes the UI/Graphing code very hard to understand. This PR is an attempt to make this code easier to understand by simplifying the shape of the timeseries data and restricting the use of Obj.magic only when passing the timeseries data to the Dygraph module. 