### PR TITLE
Add support for multi-value datapoints averaged by the benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ If you want to enroll your repository or setup this benchmark repository for you
       "metrics": {
         "<metric-1>": {"name": "benchmark-name", "value": benchmark-value, "units": "benchmark-unit", "description": "benchmark-description"},
         "<metric-2>":{"name": "num_ops", "value": [0.5, 1.5,...], "units": "ops/sec", "description": "total number of ops"},
+        "<metric-3>":{"name": "time", "value": 20, "units": "sec", "description": "time for action"},
+        "<metric-4>":{"name": "data-transfer", "value": {"min": 1, "max": 25.2, "avg": 19.8}, "units": "mbps", "description": "data transfer per second"},
         ...
       },
      ...

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -67,6 +67,7 @@ module Benchmark = {
     switch value {
     | Float(x) => LineGraph.DataRow.single(x)
     | Floats(xs) => LineGraph.DataRow.many(Array.of_list(xs))
+    | Assoc(xs) => LineGraph.DataRow.map(Array.of_list(xs))
     }
   }
 

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -66,6 +66,12 @@ module DataRow = {
     }
   }
 
+  let map = (xs: array<(string, float)>): t => {
+    open Belt.Map.String
+    let m = fromArray(xs)
+    [getWithDefault(m, "min", nan), getWithDefault(m, "avg", nan), getWithDefault(m, "max", nan)]
+  }
+
   let valueWithErrorBars = (~mid, ~low, ~high): t => [low, mid, high]
 
   let dummyValue = [nan, nan, nan]


### PR DESCRIPTION
Currently, we only support single-value datapoints, or multi-value datapoints
as a list. For a multi-value datapoint, we compute the stats (min, max, and
avg) in the frontend and display the datapoint in the graph. This commit adds
support for multi-value datapoints where these stats have been calculated by
the benchmark itself. The value can be passed as a json object: `{min: number;
max: number; avg: number}`

Closes #132