### PR TITLE
Fix broken JSON in development.conf

### DIFF
--- a/environments/development.conf
+++ b/environments/development.conf
@@ -1,6 +1,6 @@
 [
   {
-    "name": "local/local"
+    "name": "local/local",
     "image": "ocaml/opam:debian-11-ocaml-4.14"
   },
   {


### PR DESCRIPTION
Invalid JSON was accidentally committed in
59bbc3e4c7cb0ac24a7aa2a665b1758473cd2b35 and it prevents the development server
from starting up correctly. This commit fixes the JSON.