### PR TITLE
Ensure that the key "avg" is present in values which are stats

### DIFF
--- a/pipeline/lib/current_bench_json.ml
+++ b/pipeline/lib/current_bench_json.ml
@@ -99,11 +99,13 @@ module V2 = struct
         (Floats vs, units)
     | `Assoc vs ->
         let vs, units =
+          let keys = List.map (fun (key, _) -> key) vs in
+          if not (List.mem "avg" keys) then failwith "V2: Missing key *avg* in value";
           List.split
           @@ List.map
-               (fun (x, y) ->
-                 let v, u = value_of_json y in
-                 ((x, v), u))
+               (fun (key, v) ->
+                 let value, units = value_of_json v in
+                 ((key, value), units))
                vs
         in
         (Assoc vs, units)


### PR DESCRIPTION
6b792b9c0c080a7d2145051ce3631becbb348a25 added support for metrics which have
been averaged by the benchmarks themselves. This commit ensures that the "avg"
key is present in the averaged benchmarks. "min" and "max" are the other two
keys which would be nice to have, but don't break the UI if missing.