### PR TITLE
Incremental metrics

### DIFF
--- a/frontend/graphql_schema.json
+++ b/frontend/graphql_schema.json
@@ -1499,6 +1499,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "success",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "worker",
             "type": {
               "kind": "NON_NULL",
@@ -2133,6 +2145,16 @@
             "description": null
           },
           {
+            "name": "success",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "worker",
             "defaultValue": null,
             "type": {
@@ -2333,6 +2355,16 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "success",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "description": null
@@ -3204,6 +3236,16 @@
             "description": null
           },
           {
+            "name": "success",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "worker",
             "defaultValue": null,
             "type": {
@@ -3330,6 +3372,12 @@
             "isDeprecated": false,
             "deprecationReason": null,
             "name": "run_job_id",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "success",
             "description": "column name"
           },
           {
@@ -3470,6 +3518,16 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "success",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "description": null
@@ -3840,6 +3898,12 @@
             "isDeprecated": false,
             "deprecationReason": null,
             "name": "run_job_id",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "success",
             "description": "column name"
           },
           {

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -101,7 +101,7 @@ module Benchmark = {
   }
 
   @react.component
-  let make = React.memo((~repoId, ~pullNumber, ~data: GetBenchmarks.t, ~oldMetrics=false) => {
+  let make = React.memo((~repoId, ~pullNumber, ~data: GetBenchmarks.t, ~lastCommit) => {
     let benchmarkDataByTestName = React.useMemo2(() => {
       data.benchmarks->makeBenchmarkData->AdjustMetricUnit.adjust
     }, (data.benchmarks, makeBenchmarkData))
@@ -123,13 +123,13 @@ module Benchmark = {
       ->Belt.Map.String.valuesToArray
     }, [benchmarkDataByTestName])
 
-    <Column spacing=Sx.xl sx={oldMetrics ? [Sx.opacity25] : []}>
+    <Column spacing=Sx.xl>
       {graphsData
       ->Belt.List.fromArray
       ->Belt.List.sort(((_, _, _, idx1), (_, _, _, idx2)) => idx1 - idx2)
       ->Belt.List.toArray
       ->Belt.Array.map(((dataByMetricName, comparison, testName, _)) =>
-        <BenchmarkTest repoId pullNumber key={testName} testName dataByMetricName comparison />
+        <BenchmarkTest repoId pullNumber key={testName} testName dataByMetricName comparison lastCommit />
       )
       ->Rx.array(~empty=<Message text="No data for selected interval." />)}
     </Column>
@@ -148,7 +148,7 @@ module BenchmarkView = {
       )
     }
 
-    let (oldMetrics, setOldMetrics) = React.useState(() => false)
+    let (lastCommit, setLastCommit) = React.useState(() => None)
 
     switch response {
     | Empty => <div> {"Something went wrong!"->Rx.text} </div>
@@ -158,8 +158,8 @@ module BenchmarkView = {
     | Data(data)
     | PartialData(data, _) =>
       <Block sx=[Sx.px.xl2, Sx.py.xl2, Sx.w.full, Sx.minW.zero]>
-        <CommitInfo repoId worker ?pullNumber benchmarks=data setOldMetrics />
-        <Benchmark repoId pullNumber data oldMetrics />
+        <CommitInfo repoId worker ?pullNumber setLastCommit />
+        <Benchmark repoId pullNumber data lastCommit />
       </Block>
     }
   }

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -110,7 +110,7 @@ let make = (
     </Table>
   }
 
-  let metric_graphs = React.useMemo1(() => {
+  let metric_graphs = React.useMemo2(() => {
     dataByMetricName
     ->Belt.Map.String.mapWithKey((metricName, (timeseries, metadata)) => {
       let (comparisonTimeseries, comparisonMetadata) = Belt.Map.String.getWithDefault(
@@ -188,7 +188,7 @@ let make = (
     })
     ->Belt.Map.String.valuesToArray
     ->Rx.array
-  }, [dataByMetricName])
+  }, (dataByMetricName, lastCommit))
 
   <details className={Sx.make([Sx.w.full])} open_=true>
     <summary

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -78,6 +78,7 @@ let make = (
   ~testName,
   ~comparison=Belt.Map.String.empty,
   ~dataByMetricName: Belt.Map.String.t<(array<LineGraph.DataRow.t>, 'a)>,
+  ~lastCommit
 ) => {
   let metric_table = {
     <Table sx=[Sx.mb.xl2]>
@@ -167,7 +168,11 @@ let make = (
       | _ => BeltHelpers.Array.lastExn(metadata)["description"]
       }
 
-      <div key=metricName>
+      let oldMetrics =
+        metadata
+        ->Belt.Array.every((m) => { Some(m["commit"]) != lastCommit })
+
+      <div key=metricName  className={Sx.make(oldMetrics ? [Sx.opacity25] : [])}>
         {Topbar.anchor(~id="line-graph-" ++ testName ++ "-" ++ metricName)}
         <LineGraph
           onXLabelClick={AppHelpers.goToCommitLink(~repoId)}

--- a/frontend/src/CommitInfo.res
+++ b/frontend/src/CommitInfo.res
@@ -154,10 +154,6 @@ let make = (~repoId, ~pullNumber=?, ~worker, ~setLastCommit) => {
   | PartialData(data, _) =>
     let lastCommitInfo = data.lastCommitInfo[0]
     setLastCommit(Some(lastCommitInfo.commit))
-    let lastBenchmark = Belt.Array.get(
-      benchmarks.benchmarks,
-      Belt.Array.length(benchmarks.benchmarks) - 1,
-    )
     let sameBuildJobLog = switch (lastCommitInfo.build_job_id, lastCommitInfo.run_job_id) {
     | (Some(buildID), Some(jobID)) => buildID == jobID
     | (_, _) => false
@@ -228,28 +224,6 @@ let make = (~repoId, ~pullNumber=?, ~worker, ~setLastCommit) => {
           }}
         </Column>
       </Row>
-      {switch status {
-      | Fail
-      | Cancel
-      | Running =>
-        switch lastBenchmark {
-        | None => Rx.null
-        | Some(benchmark) => <>
-            <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.yellow600)]>
-              "Metrics for an older commit "
-            </Text>
-            {renderCommitLink(
-              ~style=[Sx.text.bold, Sx.text.xs, Sx.p.zero],
-              repoId,
-              benchmark.commit,
-            )}
-            <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.yellow600)]>
-              " are shown below"
-            </Text>
-          </>
-        }
-      | _ => Rx.null
-      }}
     </>
   }
 }

--- a/frontend/src/CommitInfo.res
+++ b/frontend/src/CommitInfo.res
@@ -1,5 +1,4 @@
 open Components
-open BenchmarkQueryHelpers
 
 module GetLastCommitInfo = %graphql(`
 query ($repoId: String!,
@@ -25,6 +24,7 @@ query ($repoId: String!,
     run_job_id
     failed
     cancelled
+    success
     reason
     pr_title
     worker
@@ -88,20 +88,20 @@ let renderCommitLink = (~style=linkStyle, repoId, commit) =>
 
 type status = Cancel | Fail | Pass | Running
 
-let buildStatus = (lastCommitInfo: GetLastCommitInfo.t_lastCommitInfo, noCommitMetrics) => {
+let buildStatus = (lastCommitInfo: GetLastCommitInfo.t_lastCommitInfo) => {
   if lastCommitInfo.cancelled->Belt.Option.getWithDefault(false) {
     Cancel
   } else if lastCommitInfo.failed->Belt.Option.getWithDefault(false) {
     Fail
-  } else if noCommitMetrics {
-    Running
-  } else {
+  } else if lastCommitInfo.success->Belt.Option.getWithDefault(false) {
     Pass
+  } else {
+    Running
   }
 }
 
 @react.component
-let make = (~repoId, ~pullNumber=?, ~worker, ~benchmarks: GetBenchmarks.t, ~setOldMetrics) => {
+let make = (~repoId, ~pullNumber=?, ~worker, ~setLastCommit) => {
   let (worker, dockerImage) = switch worker {
     | None => (None, None)
     | Some((worker, dockerImage)) => (Some(worker), Some(dockerImage))
@@ -116,57 +116,53 @@ let make = (~repoId, ~pullNumber=?, ~worker, ~benchmarks: GetBenchmarks.t, ~setO
   // NOTE: This function needs to be called in all the branches of the switch,
   // if not we see a React Warning about a change in the order of Hooks called
   // by CommitInfo. (See https://reactjs.org/link/rules-of-hooks)
-  let showingOldMetrics = flag => {
+  let setLastCommit = flag => {
     // NOTE: We cannot directly call `setOldMetrics(_ => noCommitMetrics)` in
     // the success branch, since it is not recommended to update a component
     // (`App$BenchmarkView`) while rendering a different component
     // (`CommitInfo`). So, we wrap it in useEffect. (See
     // https://reactjs.org/link/setstate-in-render)
     React.useEffect(() => {
-      setOldMetrics(_ => flag)
+      setLastCommit(_ => flag)
       None
     })
   }
 
   switch response {
   | Empty => {
-      showingOldMetrics(false)
+      setLastCommit(None)
       <div> {"Something went wrong!"->Rx.text} </div>
     }
   | Error({networkError: Some(_)}) => {
-      showingOldMetrics(false)
+      setLastCommit(None)
       <div> {"Network Error"->Rx.text} </div>
     }
   | Error({networkError: None}) => {
-      showingOldMetrics(false)
+      setLastCommit(None)
       <div> {"Unknown Error"->Rx.text} </div>
     }
   | Fetching => {
-      showingOldMetrics(false)
+      setLastCommit(None)
       Rx.text("Loading...")
     }
   | Data({lastCommitInfo: []})
   | PartialData({lastCommitInfo: []}, _) => {
-      showingOldMetrics(false)
+      setLastCommit(None)
       Rx.null
     }
   | Data(data)
   | PartialData(data, _) =>
     let lastCommitInfo = data.lastCommitInfo[0]
+    setLastCommit(Some(lastCommitInfo.commit))
     let lastBenchmark = Belt.Array.get(
       benchmarks.benchmarks,
       Belt.Array.length(benchmarks.benchmarks) - 1,
     )
-    let noCommitMetrics = switch lastBenchmark {
-    | None => true
-    | Some(benchmark) => benchmark.commit != lastCommitInfo.commit
-    }
     let sameBuildJobLog = switch (lastCommitInfo.build_job_id, lastCommitInfo.run_job_id) {
     | (Some(buildID), Some(jobID)) => buildID == jobID
     | (_, _) => false
     }
-    showingOldMetrics(noCommitMetrics)
-    let status = buildStatus(lastCommitInfo, noCommitMetrics)
+    let status = buildStatus(lastCommitInfo)
     <>
       {switch lastCommitInfo.pull_number {
       | Some(pullNumber) => {

--- a/hasura-server/metadata/tables.yaml
+++ b/hasura-server/metadata/tables.yaml
@@ -38,6 +38,7 @@
       - run_job_id
       - failed
       - cancelled
+      - success
       - reason
       - pr_title
       - worker

--- a/local-test-repo/Makefile
+++ b/local-test-repo/Makefile
@@ -6,45 +6,33 @@ define BENCH_DATA_1
     {
       "name": "bench_1_test_1",
       "metrics": [
-	{
-	  "name": "time",
-	  "value": 8.02,
-	  "units": "secs",
-	  "description": "The total time to do awesome $job"
-	},
-	{
-	  "name": "ops_per_sec",
-	  "value": 690.0,
-	  "units": "num/sec",
-	  "description": "The number of awesome things done in a second"
-	},
-	{
-	  "name": "mbs_per_sec",
-	  "value": 199,
-	  "units": "mbps",
-	  "description": "Quantity of awesome data downloaded"
-	}
+        {
+          "name": "time",
+          "value": 8.02,
+          "units": "secs",
+          "description": "The total time to do awesome $job"
+        },
+        {
+          "name": "ops_per_sec",
+          "value": 690.0,
+          "units": "num/sec",
+          "description": "The number of awesome things done in a second"
+        },
+        {
+          "name": "mbs_per_sec",
+          "value": 199,
+          "units": "mbps",
+          "description": "Quantity of awesome data downloaded"
+        }
       ]
     },
     {
       "name": "bench_1_test_2",
-      "metrics": [
-	{
-	  "name": "time",
-	  "value": 10.04,
-	  "units": "secs"
-	},
-	{
-	  "name": "ops_per_sec",
-	  "value": 1455.0,
-	  "units": "num/sec"
-	},
-	{
-	  "name": "mbs_per_sec",
-	  "value": 17.0,
-	  "units": "mbps"
-	}
-      ]
+      "metrics": {
+        "time": "11.04secs",
+        "ops_per_sec": "1455.0num/sec",
+        "mbs_per_sec": "17.0mbps"
+      }
     }
   ]
 }
@@ -58,41 +46,41 @@ define BENCH_DATA_2
     {
       "name": "bench_2_test_1",
       "metrics": [
-	{
-	  "name": "time",
-	  "value": 0.01,
-	  "units": "secs"
-	},
-	{
-	  "name": "ops_per_sec",
-	  "value": 50.0,
-	  "units": "num/sec"
-	},
-	{
-	  "name": "mbs_per_sec",
-	  "value": 3.0,
-	  "units": "mbps"
-	}
+        {
+          "name": "time",
+          "value": 0.01,
+          "units": "secs"
+        },
+        {
+          "name": "ops_per_sec",
+          "value": 50.0,
+          "units": "num/sec"
+        },
+        {
+          "name": "mbs_per_sec",
+          "value": 3.0,
+          "units": "mbps"
+        }
       ]
     },
     {
       "name": "bench_2_test_2",
       "metrics": [
-	{
-	  "name": "time",
-	  "value": 0.07,
-	  "units": "secs"
-	},
-	{
-	  "name": "ops_per_sec",
-	  "value": 877.0,
-	  "units": "num/sec"
-	},
-	{
-	  "name": "mbs_per_sec",
-	  "value": 23.0,
-	  "units": "mbps"
-	}
+        {
+          "name": "time",
+          "value": 0.07,
+          "units": "secs"
+        },
+        {
+          "name": "ops_per_sec",
+          "value": 877.0,
+          "units": "num/sec"
+        },
+        {
+          "name": "mbs_per_sec",
+          "value": 23.0,
+          "units": "mbps"
+        }
       ]
     }
   ]

--- a/pipeline/db/migrations/20211127170118_benchmark_metadata_success.down.sql
+++ b/pipeline/db/migrations/20211127170118_benchmark_metadata_success.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE benchmark_metadata
+DROP COLUMN success;

--- a/pipeline/db/migrations/20211127170118_benchmark_metadata_success.up.sql
+++ b/pipeline/db/migrations/20211127170118_benchmark_metadata_success.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE benchmark_metadata
+ADD COLUMN success BOOLEAN DEFAULT FALSE;

--- a/pipeline/lib/json_stream.ml
+++ b/pipeline/lib/json_stream.ml
@@ -1,13 +1,9 @@
-let validate_json json_list =
-  try Current_bench_json.(validate (List.map of_json json_list))
-  with Failure m ->
-    Fmt.failwith "Benchmark JSON validation failed with error: %s" m
-
 let db_save ~conninfo benchmark output =
   output
   |> Util.parse_jsons
-  |> validate_json
-  |> Hashtbl.iter (fun benchmark_name (version, results) ->
+  |> Current_bench_json.of_list
+  |> Current_bench_json.to_list
+  |> List.iter (fun (benchmark_name, version, results) ->
          results
          |> List.mapi (fun test_index res ->
                 benchmark ~version ~benchmark_name ~test_index res)

--- a/pipeline/lib/models.ml
+++ b/pipeline/lib/models.ml
@@ -112,7 +112,8 @@ module Benchmark = struct
       Fmt.str
         {|INSERT INTO benchmarks(version, run_at, duration, repo_id, commit, branch, pull_number, build_job_id, run_job_id, worker, docker_image, benchmark_name, test_name,  test_index, metrics)
           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-          ON CONFLICT (commit, test_name, run_job_id) DO NOTHING
+          ON CONFLICT (commit, test_name, run_job_id)
+          DO UPDATE SET metrics = EXCLUDED.metrics
         |}
         version run_at duration repository commit branch pull_number
         build_job_id run_job_id worker docker_image benchmark_name test_name

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -114,7 +114,8 @@ let pipeline ~ocluster ~conninfo ~repository env =
   in
   let worker_job_id = get_job_id ocluster_worker in
   let output =
-    Json_stream.save ~conninfo ~repository ~worker ~docker_image worker_job_id
+    Json_stream.save ~conninfo ~repository ~serial_id ~worker ~docker_image
+      worker_job_id
   in
   let+ () =
     record_pipeline_stage ~stage:"build_job_id" ~serial_id ~conninfo


### PR DESCRIPTION
This PR writes the json metrics into the database as soon as they are available (rather than at the end of `make bench`). This allows the benchmark to produce a log metric by metric:

```
...debug info...
{"results":[{"name":"test", "metrics":{"time":"14.0s"}}]}
...blabla...
{"results":[{"name":"test", "metrics":{"time":"15.0s"}}]}
...etc...
```
The final json will accumulate the different results. At the end of the run, the result in the db is the same as if this json had been produced:

```
{"results":[{"name":"test", "metrics":[{"name":"time","value":[14.0,15.0],"units":"s"}]}]}
```

On the frontend, the graphs are revealed progressively as soon as they have a value for the tested commit. This allow to check on the benchmark progress, and might also be a more convenient interface for producing "repeated runs".

```
for i in $(seq 1 10); do make bench; done
```

As a side effect, an old benchmark graph for which values are not produced anymore will stay at a low opacity (implicit deprecation).
