### PR TITLE
Add missing size units to the sizeRegex

### DIFF
--- a/frontend/src/AdjustMetricUnit.res
+++ b/frontend/src/AdjustMetricUnit.res
@@ -1,6 +1,5 @@
 let sizeUnits = ["bytes", "kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"]
-// FIXME: Should include other units too?!
-let sizeRegex = %re("/(gb|mb|kb|bytes)\w*/i")
+let sizeRegex = %re("/(yb|zb|eb|pb|tb|gb|mb|kb|bytes)\w*/i")
 let isSize = x => Js.Re.exec_(sizeRegex, x)->Belt.Option.isSome
 
 let getUnitsIndex = units => {


### PR DESCRIPTION
Previously some of the size units were missing from the sizeRegex, which are
included in the sizeUnits array. This commit adds those units to the
sizeRegex. The units are explicitly listed down in the regex, because %re can
only be called on literal strings.