### PR TITLE
Basic Prometheus and Alertmanager config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build
 environments/cb-dev-test.pem
 environments/github.secret
 capnp-secrets
+/prometheus/scripts/node_exporter*

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,7 @@ start-prometheus-alertmanager:
 stop-prometheus-alertmanager:
 	cd ./prometheus/ && \
 	docker-compose --env-file=../environments/production.env down
+
+.PHONY: start-node-exporter
+start-node-exporter:
+	./prometheus/scripts/start-node-exporter.sh --web.listen-address 0.0.0.0:10080

--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,13 @@ rebuild-pipeline: ./local-test-repo/.git
 .PHONY: bench
 bench:
 	@cd ./local-test-repo/ && make -s bench
+
+.PHONY: start-prometheus-alertmanager
+start-prometheus-alertmanager:
+	cd ./prometheus/ && \
+	docker-compose --env-file=../environments/production.env up --detach
+
+.PHONY: stop-prometheus-alertmanager
+stop-prometheus-alertmanager:
+	cd ./prometheus/ && \
+	docker-compose --env-file=../environments/production.env down

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -1,0 +1,12 @@
+global:
+  resolve_timeout: 1m
+  slack_api_url: $ALERTMANAGER_SLACK_API_URL
+
+route:
+  receiver: 'slack-notifications'
+
+receivers:
+- name: 'slack-notifications'
+  slack_configs:
+  - channel: '#c-admin'
+    send_resolved: true

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -9,3 +9,12 @@ groups:
       annotations:
         summary: Prometheus not connected to alertmanager (instance {{ $labels.instance }})
         description: "Prometheus cannot connect to the alertmanager\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+    - alert: PrometheusTargetMissing
+      expr: up == 0
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Prometheus target missing (instance {{ $labels.instance }})
+        description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: prometheus
+    rules:
+    - alert: PrometheusNotConnectedToAlertmanager
+      expr: prometheus_notifications_alertmanagers_discovered < 1
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Prometheus not connected to alertmanager (instance {{ $labels.instance }})
+        description: "Prometheus cannot connect to the alertmanager\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/prometheus/docker-compose.yml
+++ b/prometheus/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.32.1
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./alerts.yml:/etc/prometheus/alerts.yml
+      - prometheus-data:/prometheus
+    command: --web.enable-lifecycle  --config.file=/etc/prometheus/prometheus.yml
+
+  alertmanager:
+    image: prom/alertmanager:v0.23.0
+    restart: unless-stopped
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./alertmanager.yml:/config/alertmanager.yml
+      - ./scripts:/scripts
+      - alertmanager-data:/data
+    entrypoint: ["/scripts/start-alertmanager.sh"]
+    environment:
+      - ALERTMANAGER_SLACK_API_URL=${ALERTMANAGER_SLACK_API_URL?required}
+
+volumes:
+  prometheus-data:
+  alertmanager-data:

--- a/prometheus/docker-compose.yml
+++ b/prometheus/docker-compose.yml
@@ -8,8 +8,11 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - ./alerts.yml:/etc/prometheus/alerts.yml
+      - ./scripts:/scripts
       - prometheus-data:/prometheus
-    command: --web.enable-lifecycle  --config.file=/etc/prometheus/prometheus.yml
+    entrypoint: ["/scripts/start-prometheus.sh"]
+    environment:
+      - OCAML_BENCH_CLUSTER_POOLS=${OCAML_BENCH_CLUSTER_POOLS?required}
 
   alertmanager:
     image: prom/alertmanager:v0.23.0

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,6 +11,10 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets: ['localhost:9090', 'alertmanager:9093']
+  - job_name: 'node'
+    scrape_interval: 5s
+    static_configs:
+      - targets: [ $PROMETHEUS_SCRAPE_TARGETS ]
 
 alerting:
   alertmanagers:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,22 @@
+global:
+  scrape_interval: 5s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'current-bench-monitor'
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9090', 'alertmanager:9093']
+
+alerting:
+  alertmanagers:
+    - scheme: http
+      static_configs:
+        - targets: [ 'alertmanager:9093' ]
+
+rule_files:
+  - /etc/prometheus/alerts.yml

--- a/prometheus/scripts/start-alertmanager.sh
+++ b/prometheus/scripts/start-alertmanager.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Script to start alertmanager.
+set -eu
+
+# Alertmanager doesn't provide a way to replace config variables, and we need
+# to write our own script to do this. See
+# https://github.com/prometheus/alertmanager/issues/504
+
+sed "s|\$ALERTMANAGER_SLACK_API_URL|$ALERTMANAGER_SLACK_API_URL|g" /config/alertmanager.yml > /tmp/alertmanager.yml  # Permissions to write to the same file is a problem, so we write a /tmp file
+alertmanager --config.file=/tmp/alertmanager.yml --log.level=debug

--- a/prometheus/scripts/start-node-exporter.sh
+++ b/prometheus/scripts/start-node-exporter.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+NODE_EXPORTER_VERSION=1.3.1
+NODE_EXPORTER_EXE="node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64/node_exporter"
+
+download_and_extract () {
+    wget -c "https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz"
+    tar xvfz "node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz"
+}
+
+pushd $(dirname $0)
+
+if [ ! -f ${NODE_EXPORTER_EXE} ]; then
+    download_and_extract
+fi
+
+${NODE_EXPORTER_EXE} "$@"

--- a/prometheus/scripts/start-prometheus.sh
+++ b/prometheus/scripts/start-prometheus.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Script to start prometheus.
+set -eu
+
+# Prometheus doesn't provide a way to replace config variables, and we need
+# to write our own script to do this. See
+# https://github.com/prometheus/prometheus/issues/2357
+
+PROMETHEUS_SCRAPE_TARGETS=$(echo $OCAML_BENCH_CLUSTER_POOLS|sed -E "s|(\w)+|'\0.ocamllabs.io:10080'|g")
+
+sed "s|\$PROMETHEUS_SCRAPE_TARGETS|$PROMETHEUS_SCRAPE_TARGETS|g" /etc/prometheus/prometheus.yml > /tmp/prometheus.yml  # Permissions to write to the same file is a problem, so we write a /tmp file
+
+prometheus --web.enable-lifecycle  --config.file=/tmp/prometheus.yml


### PR DESCRIPTION
This PR adds basic configuration to get alertmanager and prometheus running, and adds a basic alert to verify that prometheus is able to connect to alertmanager. 

The Slack webhook api URL needs to be configured, and I don't have the permissions to add a new incoming webhook in our Slack instance. I'd need help with that. 

The expectation is to run node exporters on each of the nodes/cluster workers, and add alerts for some basic metrics. I'll add the scripts to get this running in a separate PR. 