### PR TITLE
Ignore NaNs when computing the mean

### DIFF
--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -20,7 +20,7 @@ let computeMean = xs => {
     None
   } else {
     let (total, count) = Array.fold_left(
-      ((total, count), x) => Js.Float.isNaN(x) ? (total, count +. 1.) : (total +. x, count +. 1.),
+      ((total, count), x) => Js.Float.isNaN(x) ? (total, count) : (total +. x, count +. 1.),
       (0., 0.),
       xs,
     )

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -19,15 +19,11 @@ let computeMean = xs => {
   if Array.length(xs) == 0 {
     None
   } else {
-    let (total, count) = Array.fold_left(((total, count), x) => {
-      if Js.Float.isNaN(x) {
-        (total, count +. 1.)
-      } else {
-        let total = total +. x
-        let count = count +. 1.
-        (total, count)
-      }
-    }, (0., 0.), xs)
+    let (total, count) = Array.fold_left(
+      ((total, count), x) => Js.Float.isNaN(x) ? (total, count +. 1.) : (total +. x, count +. 1.),
+      (0., 0.),
+      xs,
+    )
     Some(total /. count)
   }
 }


### PR DESCRIPTION
Previously, the mean included the count for the number of points, but ignored
NaN values. This seemed to make the mean value meaningless. This commit changes
the computation to completely ignore the mean values.