### PR TITLE
Support overlaying graphs using metric names to specify hierarchy

### DIFF
--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -227,7 +227,7 @@ let make = (
     let oldMetrics = metadata->Belt.Array.every(m => {Some(m["commit"]) != lastCommit})
     let units = (metadata->BeltHelpers.Array.lastExn)["units"]
     let data = timeseries->Belt.Array.sliceToEnd(-20)
-    let labels = ["idx", "value"]
+    let labels = ["value"]
     let firstPullX = Belt.Array.length(comparisonTimeseries)
     let annotations =
       firstPullX > 0 ? [makeAnnotation(firstPullX, "value", repoId, pullNumber)] : []

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -171,9 +171,9 @@ let make = (
       Belt.Map.Int.set(acc, index, tick)
     })
 
-    let annotations = if Belt.Array.length(comparisonTimeseries) > 0 {
-      let firstPullX = Belt.Array.length(comparisonTimeseries)
-      [
+    let firstPullX = Belt.Array.length(comparisonTimeseries)
+    let annotations = switch firstPullX > 0 {
+    | true => [
         {
           "series": "value",
           "x": firstPullX,
@@ -192,8 +192,7 @@ let make = (
           },
         },
       ]
-    } else {
-      []
+    | _ => []
     }
     let row = getRowData(
       ~comparison=(comparisonTimeseries, comparisonMetadata),

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -290,9 +290,8 @@ let make = (
         : [metricName]
       let seriesArrays =
         names->Belt.Array.map(x => getSeriesArrays(dataByMetricName, comparison, x))
-      // FIXME: Validate that units are same on all the overlays? (ideally, in the current_bench_json.ml)
-      // This could also be broken by the code that adjusts size metrics, even if validated in the pipeline
       let (timeseries, metadata, comparisonTimeseries, comparisonMetadata) = seriesArrays[0]
+      // FIXME: Validate that units are same on all the overlays? (ideally, in the current_bench_json.ml)
       let mergedMetadata = isOverlayed ? mergeMetadata(seriesArrays) : metadata
       let tsArrays = fillMissingValues(seriesArrays, mergedMetadata)
       let xTicks = mergedMetadata->Belt.Array.reduceWithIndex(Belt.Map.Int.empty, (

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -163,9 +163,7 @@ let make = (
 
     let xTicks = Belt.Array.reduceWithIndex(timeseries, Belt.Map.Int.empty, (acc, _, index) => {
       let tick = switch Belt.Array.get(metadata, index) {
-      | Some(xMetadata) =>
-        let xValue = xMetadata["commit"]
-        DataHelpers.trimCommit(xValue)
+      | Some(m) => DataHelpers.trimCommit(m["commit"])
       | None => "Unknown"
       }
       Belt.Map.Int.set(acc, index, tick)

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -225,19 +225,16 @@ let make = (
     }
 
     let oldMetrics = metadata->Belt.Array.every(m => {Some(m["commit"]) != lastCommit})
+    let units = (metadata->BeltHelpers.Array.lastExn)["units"]
+    let data = timeseries->Belt.Array.sliceToEnd(-20)
+    let labels = ["idx", "value"]
+    let title = metricName
+    let onXLabelClick = AppHelpers.goToCommitLink(~repoId)
+    let id = `line-graph-${testName}-${title}`
 
     <div key=metricName className={Sx.make(oldMetrics ? [Sx.opacity25] : [])}>
-      {Topbar.anchor(~id="line-graph-" ++ testName ++ "-" ++ metricName)}
-      <LineGraph
-        onXLabelClick={AppHelpers.goToCommitLink(~repoId)}
-        title=metricName
-        subTitle
-        xTicks
-        data={timeseries->Belt.Array.sliceToEnd(-20)}
-        units={(metadata->BeltHelpers.Array.lastExn)["units"]}
-        annotations
-        labels=["idx", "value"]
-      />
+      {Topbar.anchor(~id)}
+      <LineGraph onXLabelClick title subTitle xTicks data units annotations labels />
     </div>
   }
 

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -270,8 +270,8 @@ let containerSx = [Sx.w.full, Sx.border.xs, Sx.border.color(Sx.gray300), Sx.roun
 open Components
 
 type elementOrString =
-    | String(string)
-    | Element(React.element)
+  | String(string)
+  | Element(React.element)
 
 @react.component
 let make = React.memo((

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -231,7 +231,7 @@ let defaultOptions = (
     "customBars": true,
     "fillGraph": false,
     "pointClickCallback": Js.Null.fromOption(onClick),
-    "colors": ["#0F6FDE"],
+    "colors": ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"],
     // "animatedZooms": true,
     "digitsAfterDecimal": 3,
     "hideOverlayOnMouseOut": true,

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -206,6 +206,7 @@ let defaultOptions = (
     },
     "series": {
       "mean": {
+        "color": "#888888",
         "strokeWidth": 1.0,
         "strokePattern": [3, 2],
         "highlightCircleSize": 0,
@@ -222,7 +223,7 @@ let defaultOptions = (
     "customBars": true,
     "fillGraph": false,
     "pointClickCallback": Js.Null.fromOption(onClick),
-    "colors": ["#0F6FDE", "#888888"],
+    "colors": ["#0F6FDE"],
     // "animatedZooms": true,
     "digitsAfterDecimal": 3,
     "hideOverlayOnMouseOut": true,

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -312,7 +312,7 @@ let make = React.memo((
     DataRow.valueWithErrorBars(~mid=mean, ~low=mean -. stdDev, ~high=mean +. stdDev)
   }
   let labels = labels->Belt.Option.map(labels => {
-    labels->BeltHelpers.Array.add("mean")
+    Belt.Array.concatMany([["idx"], labels, ["mean"]])
   })
 
   let makeDygraphData = (data: array<DataRow.t>) => {

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -404,7 +404,7 @@ let make = React.memo((
     None
   }, (data, annotations))
 
-  let lastValue = data->Belt.Array.getExn(Belt.Array.length(data) - 1)
+  let lastValue = data->BeltHelpers.Array.lastExn
 
   let left = switch title {
   | Some(title) =>

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -138,10 +138,11 @@ module Legend = {
         ("<div>" ++ labelHTML ++ "&ndash; </div>") ++
         ("<div>" ++ " <b>" ++ yHTML ++ "</b>" ++ "</div>" ++ "</div>"))
       }
+      let statsIndex = 1  // data.series contains legend entries for each line we show (currently, data and stats)
       let legend = Array.mapi((idx, unit: t) => {
         // Add extra header for overall stats
-        let extraHeader = switch unit.label {
-        | "mean" => "<b>Overall Stats</b>"
+        let extraHeader = switch idx == statsIndex {
+        | true => "<b>Overall Stats</b>"
         | _ => ""
         }
         // We check if the data point was originally a multi-value data point,
@@ -156,7 +157,7 @@ module Legend = {
         let rawToFloat = x =>
           x->Js.Nullable.toOption->Belt.Option.getExn->Js.Float.toPrecisionWithPrecision(~digits=4)
         let extraHTML = switch multiValue {
-        | true if unit.label != "mean" =>
+        | true if idx < statsIndex =>
           row(unit.dashHTML, "min", min->rawToFloat) ++ row(unit.dashHTML, "max", max->rawToFloat)
         | _ => ""
         }

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -129,6 +129,8 @@ module Legend = {
     | Some(xTicks) => Belt.Map.Int.get(xTicks, data.x)
     | None => Some(data.xHTML)
     }
+    // Starting index for the stats. (data.series contains legend entries for each line we show - data followed by stats)
+    let statsIndex = Array.length(data.series) / 2
     switch xLabel {
     | Some(xLabel) =>
       let html = "<b>" ++ xLabel ++ "</b>"
@@ -138,7 +140,6 @@ module Legend = {
         ("<div>" ++ labelHTML ++ "&ndash; </div>") ++
         ("<div>" ++ " <b>" ++ yHTML ++ "</b>" ++ "</div>" ++ "</div>"))
       }
-      let statsIndex = 1  // data.series contains legend entries for each line we show (currently, data and stats)
       let legend = Array.mapi((idx, unit: t) => {
         // Add extra header for overall stats
         let extraHeader = switch idx == statsIndex {
@@ -189,6 +190,20 @@ let defaultOptions = (
   let ticker = {
     xTicks->Belt.Option.map(convertTicks)->Belt.Option.map((x, ()) => x)->Js.Null.fromOption
   }
+  let statsIndex = labels->Belt.Option.getExn->Array.length / 2 + 1
+  let series =
+    labels
+    ->Belt.Option.getExn
+    ->Belt.Array.sliceToEnd(statsIndex)
+    ->Belt.Array.map(x => {
+      %raw(`{[x]: {
+        "color": "#888888",
+        "strokeWidth": 1.0,
+        "strokePattern": [3, 2],
+        "highlightCircleSize": 0,
+      }}`)
+    })
+  let series = series->Belt.Array.reduce(Js.Obj.empty(), (acc, s) => Js.Obj.assign(acc, s))
   {
     "file": data,
     "axes": {
@@ -204,14 +219,7 @@ let defaultOptions = (
         "axisLabelWidth": 55,
       },
     },
-    "series": {
-      "mean": {
-        "color": "#888888",
-        "strokeWidth": 1.0,
-        "strokePattern": [3, 2],
-        "highlightCircleSize": 0,
-      },
-    },
+    "series": series,
     "showRoller": false,
     "rollPeriod": 1,
     "xRangePad": 0,
@@ -292,7 +300,7 @@ let make = React.memo((
     "width": int,
     "x": int,
   }>=[],
-  ~data,
+  ~dataSet: array<DataRow.row>,
   ~units: DataRow.units,
 ) => {
   let graphDivRef = React.useRef(Js.Nullable.null)
@@ -305,31 +313,43 @@ let make = React.memo((
     ->Belt.Option.map(IntersectionObserver.Entry.isIntersecting)
     ->Belt.Option.getWithDefault(false)
 
-  // Add constant stdDev series.
-  let constantSeries = {
+  let computeConstantSeries = data => {
     let values = data->Belt.Array.map(DataRow.toValue)
     let mean = values->computeMean->Belt.Option.getWithDefault(0.0)
     let stdDev = computeStdDev(~mean, values)
     DataRow.valueWithErrorBars(~mid=mean, ~low=mean -. stdDev, ~high=mean +. stdDev)
   }
+  let constantSeries = dataSet->Belt.Array.map(computeConstantSeries)
+
+  // Dygraph needs null values, and cannot handle NaNs correctly
+  let convertNanToNull = (xs: DataRow.t) =>
+    Belt.Array.map(xs, x => Js.Float.isNaN(x) ? Obj.magic(Js.null) : x)
+
+  let nullConstantSeries = constantSeries->Belt.Array.map(convertNanToNull)
+
   let labels = labels->Belt.Option.map(labels => {
-    Belt.Array.concatMany([["idx"], labels, ["mean"]])
+    let means = Belt.Array.length(labels) > 1 ? labels->Belt.Array.map(x => "mean:" ++ x) : ["mean"]
+    Belt.Array.concatMany([["idx"], labels, means])
   })
 
-  let makeDygraphData = (data: array<DataRow.t>) => {
-    // Dygraph needs null values, and cannot handle NaNs correctly
-    let convertNanToNull = (xs: DataRow.t) =>
-      Belt.Array.map(xs, x => Js.Float.isNaN(x) ? Obj.magic(Js.null) : x)
+  let makeDygraphData = (data: array<DataRow.row>) => {
     // Dygraph does not display the last tick, so a dummy value
     // is added a the end of the data to overcome this.
     // See: https://github.com/danvk/dygraphs/issues/506
-    let data = Belt.Array.concat(data, [DataRow.dummyValue])
-    let nullConstantSeries = convertNanToNull(constantSeries)
-    Belt.Array.mapWithIndex(data, (idx, d) => [
-      Obj.magic(idx),
-      convertNanToNull(d),
-      nullConstantSeries,
-    ])
+    let data =
+      data
+      ->Belt.Array.map(x => Belt.Array.concat(x, [DataRow.dummyValue]))
+      ->Belt.Array.map(x => x->Belt.Array.map(convertNanToNull))
+
+    let n = (data->Belt.Array.map(Belt.Array.length))[0]
+    // Data passed onto Dygraph looks like array<[idx, value1, value2, ..., stats1, stats2, ...]>
+    Belt.Array.range(0, n - 1)->Belt.Array.map(idx =>
+      Belt.Array.concatMany([
+        [Obj.magic(idx)],
+        data->Belt.Array.map(d => d[idx]),
+        nullConstantSeries,
+      ])
+    )
   }
 
   React.useEffect1(() => {
@@ -346,7 +366,7 @@ let make = React.memo((
     | Some(ref) =>
       switch (graphRef.current, isIntersecting) {
       | (None, true) => {
-          let graph = init(ref, makeDygraphData(data), options)
+          let graph = init(ref, makeDygraphData(dataSet), options)
           graphRef.current = Some(graph)
 
           if Array.length(annotations) > 0 {
@@ -387,7 +407,7 @@ let make = React.memo((
           ~yLabel?,
           ~labels?,
           ~xTicks?,
-          ~data=makeDygraphData(data),
+          ~data=makeDygraphData(dataSet),
           ~legendFormatter=Legend.format(~xTicks?),
           (),
         )
@@ -404,9 +424,7 @@ let make = React.memo((
       }
     }
     None
-  }, (data, annotations))
-
-  let lastValue = data->BeltHelpers.Array.lastExn
+  }, (dataSet, annotations))
 
   let left = switch title {
   | Some(title) =>
@@ -423,12 +441,20 @@ let make = React.memo((
   | None => React.null
   }
 
+  let lastValues =
+    dataSet->Belt.Array.map(x =>
+      x->BeltHelpers.Array.lastExn->DataRow.toValue->Js.Float.toPrecisionWithPrecision(~digits=4)
+    )
+  let isOverlayed = lastValues->Belt.Array.length > 1
+  let rSize = isOverlayed ? Sx.text.lg : Sx.text.xl2
+  let valueText = isOverlayed
+    ? "[" ++ Belt.Array.joinWith(lastValues, ", ", identity) ++ "]"
+    : lastValues->BeltHelpers.Array.lastExn
+
   let right =
     <Row alignX=#right spacing=Sx.md sx=[Sx.w.auto]>
-      <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray900)]>
-        {lastValue->DataRow.toValue->Js.Float.toPrecisionWithPrecision(~digits=4)}
-      </Text>
-      <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray500)]> units </Text>
+      <Text sx=[Sx.leadingNone, rSize, Sx.text.bold, Sx.text.color(Sx.gray900)]> {valueText} </Text>
+      <Text sx=[Sx.leadingNone, rSize, Sx.text.bold, Sx.text.color(Sx.gray500)]> units </Text>
     </Row>
 
   let sx = Array.append(uSx, containerSx)

--- a/frontend/src/MetricHierarchyHelpers.res
+++ b/frontend/src/MetricHierarchyHelpers.res
@@ -1,0 +1,18 @@
+let getMetricPrefix = metricName =>
+  switch String.split_on_char('/', metricName) {
+  | list{prefix, _} => Some(prefix)
+  | _ => None
+  }
+
+let groupMetricNamesByPrefix = dataByMetricName =>
+  dataByMetricName
+  ->Belt.Map.String.keysToArray
+  ->Belt.Array.reduce(Belt.Map.String.empty, (acc, key) =>
+    switch getMetricPrefix(key) {
+    | Some(prefix) =>
+      let arr = Belt.Map.String.getWithDefault(acc, prefix, [])
+      let _ = Js.Array.push(key, arr)
+      Belt.Map.String.set(acc, prefix, arr)
+    | None => acc
+    }
+  )

--- a/local-test-repo/Makefile
+++ b/local-test-repo/Makefile
@@ -7,10 +7,21 @@ define BENCH_DATA_1
       "name": "bench_1_test_1",
       "metrics": [
 	{
-	  "name": "time",
-	  "value": 8.02,
+	  "name": "grammarFunctor/parsing",
+	  "value": 0.19,
 	  "units": "secs",
-	  "description": "The total time to do awesome $$job",
+	  "trend": "lower-is-better"
+	},
+	{
+	  "name": "grammarFunctor/typing",
+	  "value": 0.28,
+	  "units": "secs",
+	  "trend": "lower-is-better"
+	},
+	{
+	  "name": "grammarFunctor/generate",
+	  "value": 0.14,
+	  "units": "secs",
 	  "trend": "lower-is-better"
 	},
 	{


### PR DESCRIPTION
This commit adds support for overlaying graphs for metrics using metric names
to indicate hierarchy. For instance, the metrics below would be overlaid.

```json
"metrics": [
  {
    "name": "grammarFunctor/parsing",
    "units": "secs",
    "value": 0.012
  },
  {
    "name": "grammarFunctor/typing",
    "units": "secs",
    "value": 0.120
  },
  {
    "name": "grammarFunctor/generate",
    "units": "secs",
    "value": 0.257
  },
]
```

![image](https://user-images.githubusercontent.com/315678/148386879-15497973-d610-41b3-8a99-4c82c23d5090.png)
