### PR TITLE
Frontend fix: display warning and old metrics rather than an empty page

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -159,7 +159,7 @@ module BenchmarkView = {
     | Data(data)
     | PartialData(data, _) =>
       <Block sx=[Sx.px.xl2, Sx.py.xl2, Sx.w.full, Sx.minW.zero]>
-        <CommitInfo repoId worker ?pullNumber setLastCommit />
+        <CommitInfo repoId worker ?pullNumber benchmarks=data setLastCommit />
         <Benchmark repoId pullNumber data lastCommit />
       </Block>
     }


### PR DESCRIPTION
Fix for @punchagan https://github.com/ocurrent/current-bench/pull/267#discussion_r776245042 : When we don't have metrics for the latest run (because it was cancelled, failed, or still running), we display an orange warning and show the previous metrics.