### PR TITLE
Fix for production

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,10 +1,11 @@
 FROM ocaml/opam:debian-ocaml-4.13 AS build
 RUN sudo apt-get update && sudo apt-get install libc6-dev libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
 RUN opam remote add origin 'https://opam.ocaml.org' --all-switches && opam remote remove default && opam update
+RUN opam install dune>=2.8 ppx_expect>=v0.14.1 prometheus ppx_sexp_conv dune-build-info lwt>=5.4.1 capnp-rpc-lwt>=1.2 capnp-rpc-net capnp-rpc-unix>=1.2 extunix>=0.3.2 logs conf-libev digestif>=0.8 fpath lwt-dllist prometheus-app>=1.1 cohttp-lwt-unix sqlite3 psq mirage-crypto>=0.8.5 ppx_deriving ppx_deriving_yojson astring fmt>=0.8.9 cmdliner tar-unix>=2.0.0 yojson sexplib sha
 RUN mkdir src && cd src && git clone 'https://github.com/ocurrent/ocluster' && opam pin -yn ocluster
 RUN cd src && git clone 'https://github.com/ocurrent/obuilder' && opam pin -yn obuilder
 WORKDIR src/ocluster
-RUN opam install -y --deps-only .
+RUN opam install -y --deps-only ./ocluster.opam
 RUN opam config exec -- dune build \
   ./_build/install/default/bin/ocluster-scheduler \
   ./_build/install/default/bin/ocluster-admin

--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -52,9 +52,8 @@ services:
     command: ["./scripts/dev.sh"]
     ports:
       [
-        "${OCAML_BENCH_FRONTEND_PORT?required}:${OCAML_BENCH_FRONTEND_PORT?required}",
+        "8082:${OCAML_BENCH_FRONTEND_PORT?required}",
       ]
-
     restart: always
     depends_on:
       - "graphql-engine"

--- a/environments/production.docker-compose.yaml
+++ b/environments/production.docker-compose.yaml
@@ -43,7 +43,7 @@ services:
         VITE_OCAML_BENCH_GRAPHQL_URL: "${OCAML_BENCH_GRAPHQL_URL?required}"
         VITE_CURRENT_BENCH_VERSION: "${CURRENT_BENCH_VERSION?required}"
     ports:
-      - "80:${OCAML_BENCH_FRONTEND_PORT?required}"
+      - "8082:${OCAML_BENCH_FRONTEND_PORT?required}"
     restart: always
     depends_on:
       - "graphql-engine"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,7 +4,7 @@ events { worker_connections 1024; }
 
 http {
     server {
-        listen 80;
+        listen 8082;
         include /etc/nginx/mime.types;
 
         location / {


### PR DESCRIPTION
- The frontend nginx running inside docker was configured to run on port 80, but the port is already used outside of docker
- The ocluster takes a long time to build because the opam dependencies are not cached by docker