### PR TITLE
Scrape metrics from the pipeline server

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -20,6 +20,10 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets: [ $PROMETHEUS_SCRAPE_TARGETS ]
+  - job_name: 'current_bench'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['autumn.ocamllabs.io:8081']
 
 alerting:
   alertmanagers:


### PR DESCRIPTION
The ocurrent routes already configure /metrics to expose some ocaml gc metrics
and some basic metrics like github webhook stats, cache stats, etc.  This
commit configures Prometheus to scrape these metrics.