### PR TITLE
Couple of fixes with handling multiple benchmarks data

### DIFF
--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -122,7 +122,8 @@ module SidebarMenu = {
     | Fetching => Rx.text("Loading...")
     | Data({benchmarksMenuData, pullsMenuData})
     | PartialData({benchmarksMenuData, pullsMenuData}, _) => <>
-        {switch Js.Array.length(benchmarksMenuData) > 1 {
+      {
+        switch Belt.Array.some(benchmarksMenuData, bm => Belt.Option.isSome(bm.benchmark_name)) {
         | true =>
           <Column>
             <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Benchmarks" </Text>

--- a/pipeline/db/migrations/20220128083706_include_benchmark_name_benchmarks_unique_constraint.down.sql
+++ b/pipeline/db/migrations/20220128083706_include_benchmark_name_benchmarks_unique_constraint.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE benchmarks
+DROP CONSTRAINT prevent_duplicates;
+ALTER TABLE benchmarks
+ADD CONSTRAINT prevent_duplicates UNIQUE(commit, test_name, run_job_id);

--- a/pipeline/db/migrations/20220128083706_include_benchmark_name_benchmarks_unique_constraint.up.sql
+++ b/pipeline/db/migrations/20220128083706_include_benchmark_name_benchmarks_unique_constraint.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE benchmarks
+DROP CONSTRAINT prevent_duplicates;
+ALTER TABLE benchmarks
+ADD CONSTRAINT prevent_duplicates UNIQUE(commit, benchmark_name, test_name, run_job_id);

--- a/pipeline/lib/models.ml
+++ b/pipeline/lib/models.ml
@@ -112,7 +112,7 @@ module Benchmark = struct
       Fmt.str
         {|INSERT INTO benchmarks(version, run_at, duration, repo_id, commit, branch, pull_number, build_job_id, run_job_id, worker, docker_image, benchmark_name, test_name,  test_index, metrics)
           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-          ON CONFLICT (commit, test_name, run_job_id)
+          ON CONFLICT (commit, benchmark_name, test_name, run_job_id)
           DO UPDATE SET metrics = EXCLUDED.metrics
         |}
         version run_at duration repository commit branch pull_number


### PR DESCRIPTION
This PR adds a couple of fixes for handling data of benchmark runs with multiple benchmarks. We support having a list of benchmarks, when each of them should be named.

1. Hide the benchmarks menu only when unnamed benchmarks are used. 
2. Allow having test-names repeating across different benchmarks