### PR TITLE
nginx frontend: fix for urls containing slashes

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,7 +10,7 @@ http {
         location / {
             root  /usr/share/nginx/html;
             index index.html;
-            try_files $uri /index.html$is_args$args =404;
+            try_files $uri /index.html =404;
         }
     }
 }


### PR DESCRIPTION
In production, the `/` was causing some 404 not found... I believe that `/index.html$is_args$args` was expanding to `/index.html?foo=bar/blah` with the second `/` interpreted as a directory separator?

In any case, we don't need to pass arguments to the static `index.html`.