### PR TITLE
Add unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,11 @@ stop-prometheus-alertmanager:
 .PHONY: start-node-exporter
 start-node-exporter:
 	./prometheus/scripts/start-node-exporter.sh --web.listen-address 0.0.0.0:10080
+
+.PHONY: runtest
+runtest: ./local-test-repo/.git
+	docker-compose \
+		--project-name="current-bench" \
+		--file=./environments/development.docker-compose.yaml \
+		--env-file=./environments/development.env \
+		exec pipeline bash -c 'cd /mnt/project; opam exec -- dune runtest'

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -35,6 +35,8 @@ depends: [
   "postgresql"
   "rresult"
   "omigrate"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
 ]
 
 pin-depends: [

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /mnt/project
 
 # Build dependencies.
 COPY --chown=opam:opam pipeline/pipeline.opam pipeline.opam
-RUN opam install -y --deps-only -t .
+RUN opam install -y --deps-only .
 COPY --chown=opam pipeline/. .
 RUN sudo chown opam .
 

--- a/pipeline/lib/json_stream.ml
+++ b/pipeline/lib/json_stream.ml
@@ -38,7 +38,7 @@ let json_step stack chr =
   | _, (('{' | '[' | '"') as chr) -> chr :: stack
   | _ -> stack
 
-let make_json_parser () = { current = Buffer.create 16; stack = [] }
+let make_json_parser () = { current = Buffer.create 16; stack = [ '\n' ] }
 
 let json_step state chr =
   match json_step state.stack chr with
@@ -50,7 +50,7 @@ let json_step state chr =
         let str = Buffer.contents state.current in
         (Some str, make_json_parser ()))
   | hd :: _ as stack ->
-      if hd <> '\n' then Buffer.add_char state.current chr;
+      if chr <> '\n' || hd = '"' then Buffer.add_char state.current chr;
       (None, { state with stack })
 
 let json_steps (parsed, state) str =

--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -37,7 +37,7 @@ let branch t = t.branch
 let github_head t = t.github_head
 let id t = (t.owner, t.name)
 let info t = t.owner ^ "/" ^ t.name
-let frontend_url = Sys.getenv "OCAML_BENCH_FRONTEND_URL"
+let frontend_url () = Sys.getenv "OCAML_BENCH_FRONTEND_URL"
 
 (* $server/$repo_owner/$repo_name/pull/$pull_number *)
 let commit_status_url { owner; name; pull_number; _ } =
@@ -46,7 +46,7 @@ let commit_status_url { owner; name; pull_number; _ } =
     | None -> "/" ^ owner ^ "/" ^ name
     | Some number -> "/" ^ owner ^ "/" ^ name ^ "/pull/" ^ string_of_int number
   in
-  Uri.of_string (frontend_url ^ uri_end)
+  Uri.of_string (frontend_url () ^ uri_end)
 
 let compare a b =
   let cmp =

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -9,6 +9,8 @@ homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
   "dune" {>= "2.0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
   "bos"
   "capnp-rpc-unix"
   "cmdliner"
@@ -53,4 +55,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocurrent/current-bench.git"
-

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -13,7 +13,7 @@ depends: [
   "alcotest-lwt" {with-test}
   "bos"
   "capnp-rpc-unix"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "current"        {= "dev"}
   "current_docker" {= "dev"}
   "current_git"    {= "dev"}

--- a/pipeline/tests/api_test.ml
+++ b/pipeline/tests/api_test.ml
@@ -1,6 +1,6 @@
 let example_conf =
   [
-    { Config.repo = "myowner/repo"; token = "p455word!" };
+    { Config.repo = "myowner/myrepo"; token = "p455word!" };
     { Config.repo = "other/fst"; token = "token-should-be-unique" };
     { Config.repo = "other/snd"; token = "token-should-be-unique" };
   ]
@@ -16,7 +16,7 @@ let cohttp_unauth_request =
   Cohttp.Request.make uri
 
 let server_not_configured =
-  Alcotest.test_case "server not configured" `Quick @@ fun () ->
+  Alcotest_lwt.test_case_sync "server not configured" `Quick @@ fun () ->
   let req = cohttp_request ~bearer:"Bearer 123" in
   try
     let _ = Api.authenticate_token req [] in
@@ -32,7 +32,7 @@ let missing_bearer =
   with Api.Missing_token -> ()
 
 let invalid_bearer =
-  Alcotest.test_case "invalid bearer" `Quick @@ fun () ->
+  Alcotest_lwt.test_case_sync "invalid bearer" `Quick @@ fun () ->
   let req = cohttp_request ~bearer:"Missing Bearer Prefix" in
   try
     let _ = Api.authenticate_token req example_conf in
@@ -40,7 +40,7 @@ let invalid_bearer =
   with Api.Invalid_token -> ()
 
 let wrong_token =
-  Alcotest.test_case "wrong token" `Quick @@ fun () ->
+  Alcotest_lwt.test_case_sync "wrong token" `Quick @@ fun () ->
   let req = cohttp_request ~bearer:"Bearer wrong-token" in
   match Api.authenticate_token req example_conf with
   | None -> ()
@@ -50,20 +50,90 @@ let wrong_token =
            repo.Config.repo)
 
 let find_repository =
-  Alcotest.test_case "find repository" `Quick @@ fun () ->
+  Alcotest_lwt.test_case_sync "find repository" `Quick @@ fun () ->
   let req = cohttp_request ~bearer:"Bearer p455word!" in
   match Api.authenticate_token req example_conf with
   | None -> Alcotest.fail "expected a repository to be found"
   | Some repo ->
       Alcotest.(check string) "token" repo.Config.token "p455word!";
-      Alcotest.(check string) "token" repo.Config.repo "myowner/repo"
+      Alcotest.(check string) "repo" repo.Config.repo "myowner/myrepo"
 
 let find_other_repository =
-  Alcotest.test_case "find other repository" `Quick @@ fun () ->
+  Alcotest_lwt.test_case_sync "find other repository" `Quick @@ fun () ->
   let req = cohttp_request ~bearer:"Bearer token-should-be-unique" in
   match Api.authenticate_token req example_conf with
   | None -> Alcotest.fail "expected a repository to be found"
-  | Some repo -> Alcotest.(check string) "token" repo.Config.repo "other/fst"
+  | Some repo -> Alcotest.(check string) "repo" repo.Config.repo "other/fst"
+
+open Lwt.Syntax
+
+let ocurrent_site = Current_web.Site.v ~has_role:(fun _ _ -> false) []
+
+let invalid_json =
+  Alcotest_lwt.test_case "invalid json" `Quick @@ fun _ () ->
+  let conninfo = Postgresql.Mock.unused_conninfo in
+  let req = cohttp_request ~bearer:"Bearer token-should-be-unique" in
+  let body = Cohttp_lwt.Body.of_string "this is not json" in
+  let handler = Api.capture_metrics conninfo example_conf in
+  let* resp, body = handler#post_raw ocurrent_site req body in
+  let* body = Cohttp_lwt.Body.to_string body in
+  Alcotest.(check string)
+    "body" body
+    {|{"success":false,"error":"Line 1, bytes 0-16:\nInvalid token 'this is not json'"}|};
+  assert (Cohttp.Response.status resp = `Bad_request);
+  Lwt.return_unit
+
+let empty_benchmarks =
+  Alcotest_lwt.test_case "empty benchmarks" `Quick @@ fun _ () ->
+  let expected_sql =
+    [
+      Postgresql.Expect
+        (fun ?expect query ->
+          let expected =
+            "INSERT INTO benchmark_metadata (run_at, repo_id, commit, branch, \
+             pull_number, pr_title, worker, docker_image) VALUES \
+             (to_timestamp(XXX), 'myowner/myrepo', 'abcd12345', 'main', NULL, \
+             NULL, 'remote', 'external') ON CONFLICT(repo_id, commit, worker, \
+             docker_image) DO UPDATE SET build_job_id = NULL, run_job_id = \
+             NULL, failed = false, cancelled = false, success = false, reason \
+             = '' RETURNING id;"
+          in
+          Alcotest.(check string) "setup metadata" expected query;
+          assert (expect = None);
+          [| [| "421" |] |]);
+      Postgresql.Expect_finish;
+      Postgresql.Expect
+        (fun ?expect query ->
+          let expected =
+            "UPDATE benchmark_metadata SET success = true WHERE id = 421"
+          in
+          Alcotest.(check string) "success" expected query;
+          assert (expect = Some [ Postgresql.Command_ok ]);
+          [||]);
+      Postgresql.Expect_finish;
+    ]
+  in
+  Postgresql.Mock.with_mock expected_sql @@ fun ~conninfo ->
+  let req = cohttp_request ~bearer:"Bearer p455word!" in
+  let input_json =
+    `Assoc
+      [
+        ("repo_owner", `String "myowner");
+        ("repo_name", `String "myrepo");
+        ("branch", `String "main");
+        ("commit", `String "abcd12345");
+        ("run_at", `String "2021-02-03 10:11:12Z");
+        ("benchmarks", `List []);
+      ]
+  in
+  let body = Yojson.Safe.to_string input_json in
+  let body = Cohttp_lwt.Body.of_string body in
+  let handler = Api.capture_metrics conninfo example_conf in
+  let* resp, body = handler#post_raw ocurrent_site req body in
+  let* body = Cohttp_lwt.Body.to_string body in
+  Alcotest.(check string) "body" body {|{"success":true}|};
+  assert (Cohttp.Response.status resp = `OK);
+  Lwt.return_unit
 
 let tests =
   [
@@ -73,4 +143,6 @@ let tests =
     wrong_token;
     find_repository;
     find_other_repository;
+    invalid_json;
+    empty_benchmarks;
   ]

--- a/pipeline/tests/api_test.ml
+++ b/pipeline/tests/api_test.ml
@@ -1,0 +1,76 @@
+let example_conf =
+  [
+    { Config.repo = "myowner/repo"; token = "p455word!" };
+    { Config.repo = "other/fst"; token = "token-should-be-unique" };
+    { Config.repo = "other/snd"; token = "token-should-be-unique" };
+  ]
+
+(* TODO: Cohttp should not be required for testing auth *)
+let cohttp_request ~bearer =
+  let uri = Uri.of_string "http://localhost/" in
+  let headers = Cohttp.Header.of_list [ ("Authorization", bearer) ] in
+  Cohttp.Request.make ~headers uri
+
+let cohttp_unauth_request =
+  let uri = Uri.of_string "http://localhost/" in
+  Cohttp.Request.make uri
+
+let server_not_configured =
+  Alcotest.test_case "server not configured" `Quick @@ fun () ->
+  let req = cohttp_request ~bearer:"Bearer 123" in
+  try
+    let _ = Api.authenticate_token req [] in
+    Alcotest.fail "expected failure"
+  with Api.Server_config_error -> ()
+
+let missing_bearer =
+  Alcotest_lwt.test_case_sync "missing bearer" `Quick @@ fun () ->
+  let req = cohttp_unauth_request in
+  try
+    let _ = Api.authenticate_token req example_conf in
+    Alcotest.fail "expected failure"
+  with Api.Missing_token -> ()
+
+let invalid_bearer =
+  Alcotest.test_case "invalid bearer" `Quick @@ fun () ->
+  let req = cohttp_request ~bearer:"Missing Bearer Prefix" in
+  try
+    let _ = Api.authenticate_token req example_conf in
+    Alcotest.fail "expected failure"
+  with Api.Invalid_token -> ()
+
+let wrong_token =
+  Alcotest.test_case "wrong token" `Quick @@ fun () ->
+  let req = cohttp_request ~bearer:"Bearer wrong-token" in
+  match Api.authenticate_token req example_conf with
+  | None -> ()
+  | Some repo ->
+      Alcotest.fail
+        (Printf.sprintf "did not expect repository %S to be found"
+           repo.Config.repo)
+
+let find_repository =
+  Alcotest.test_case "find repository" `Quick @@ fun () ->
+  let req = cohttp_request ~bearer:"Bearer p455word!" in
+  match Api.authenticate_token req example_conf with
+  | None -> Alcotest.fail "expected a repository to be found"
+  | Some repo ->
+      Alcotest.(check string) "token" repo.Config.token "p455word!";
+      Alcotest.(check string) "token" repo.Config.repo "myowner/repo"
+
+let find_other_repository =
+  Alcotest.test_case "find other repository" `Quick @@ fun () ->
+  let req = cohttp_request ~bearer:"Bearer token-should-be-unique" in
+  match Api.authenticate_token req example_conf with
+  | None -> Alcotest.fail "expected a repository to be found"
+  | Some repo -> Alcotest.(check string) "token" repo.Config.repo "other/fst"
+
+let tests =
+  [
+    server_not_configured;
+    missing_bearer;
+    invalid_bearer;
+    wrong_token;
+    find_repository;
+    find_other_repository;
+  ]

--- a/pipeline/tests/dune
+++ b/pipeline/tests/dune
@@ -1,8 +1,8 @@
 (test
  (name test)
- (libraries alcotest current current.fs current_docker current_git
-   current_github current_ocluster capnp-rpc-unix current_web dockerfile
-   fmt.tty logs logs.fmt prometheus rresult uri postgresql yojson str)
+ (libraries alcotest alcotest-lwt current current.fs current_docker
+   current_git current_github current_ocluster capnp-rpc-unix current_web
+   dockerfile fmt.tty logs logs.fmt prometheus rresult uri yojson str)
  (preprocess
   (pps ppx_deriving_yojson)))
 

--- a/pipeline/tests/dune
+++ b/pipeline/tests/dune
@@ -1,0 +1,11 @@
+(test
+ (name test)
+ (libraries alcotest current current.fs current_docker current_git
+   current_github current_ocluster capnp-rpc-unix current_web dockerfile
+   fmt.tty logs logs.fmt prometheus rresult uri postgresql yojson str)
+ (preprocess
+  (pps ppx_deriving_yojson)))
+
+; copy everything but *.pp.ml
+
+(copy_files ../lib/**[!.]??.ml)

--- a/pipeline/tests/json_stream_test.ml
+++ b/pipeline/tests/json_stream_test.ml
@@ -1,0 +1,34 @@
+let parse_one =
+  Alcotest_lwt.test_case_sync "parse one" `Quick @@ fun () ->
+  let str =
+    String.concat "\n"
+      [
+        "debug line";
+        {|{"json": true}|};
+        "more stuff";
+        "more stuff";
+        {|{"ok": ["yes"]}|};
+        "...";
+      ]
+  in
+  let state = Json_stream.make_json_parser () in
+  let parsed, _state = Json_stream.json_steps ([], state) str in
+  let expect = [ {|{"ok": ["yes"]}|}; {|{"json": true}|} ] in
+  Alcotest.(check (list string)) "jsons" expect parsed
+
+let parse_two =
+  Alcotest_lwt.test_case_sync "parse two" `Quick @@ fun () ->
+  let str =
+    String.concat "\n" [ {|{"json": true}|}; "ignore"; "this"; {|{"ok|} ]
+  in
+  let state = Json_stream.make_json_parser () in
+  let parsed, state = Json_stream.json_steps ([], state) str in
+  let expect = [ {|{"json": true}|} ] in
+  Alcotest.(check (list string)) "jsons" expect parsed;
+  let str = String.concat "\n" [ {|": {"more":|}; {| "is coming"}}|}; "{" ] in
+  let parsed, _state = Json_stream.json_steps ([], state) str in
+  let expect = [ {|{"ok": {"more": "is coming"}}|} ] in
+  Alcotest.(check (list string)) "jsons" expect parsed;
+  ()
+
+let tests = [ parse_one; parse_two ]

--- a/pipeline/tests/postgresql.ml
+++ b/pipeline/tests/postgresql.ml
@@ -1,0 +1,94 @@
+type error = string
+
+exception Error of error
+
+let string_of_error e = e
+
+type expect = Tuples_ok | Command_ok
+
+type mock =
+  | Expect_finish
+  | Expect of (?expect:expect list -> string -> string array array)
+
+module Mock = struct
+  type t = mock
+
+  module H = Hashtbl.Make (struct
+    type t = string
+
+    let equal = String.equal
+    let hash = Hashtbl.hash
+  end)
+
+  let mocks : t list H.t = H.create 0
+  let errors : exn H.t = H.create 0
+
+  let catch ~conninfo fn =
+    try fn ~conninfo
+    with error when not (H.mem errors conninfo) ->
+      (* remember only the first failure *)
+      H.add errors conninfo error;
+      raise error
+
+  let unused_conninfo = "<db-not-used>"
+
+  let uid () =
+    let size = H.length mocks in
+    string_of_int size
+
+  let mock expected =
+    let conninfo = uid () in
+    H.add mocks conninfo expected;
+    conninfo
+
+  let pop ~conninfo =
+    match H.find mocks conninfo with
+    | mock :: rest ->
+        H.replace mocks conninfo rest;
+        mock
+    | [] -> Alcotest.fail "Postgreql.Mock.with_mock: unexpected query"
+
+  let with_mock expected fn =
+    let conninfo = mock expected in
+    Lwt.bind (fn ~conninfo) (fun result ->
+        match H.find errors conninfo with
+        | error -> raise error
+        | exception Not_found -> (
+            match H.find mocks conninfo with
+            | [] -> Lwt.return result
+            | remaining ->
+                Alcotest.fail
+                  (Printf.sprintf "Postgreql.Mock.with_mock: expected %i more"
+                     (List.length remaining))))
+end
+
+let str_trim = Str.regexp "[\n ]+"
+let str_timestamp = Str.regexp "to_timestamp([0-9.]+)"
+
+let normalize query =
+  query
+  |> Str.global_replace str_trim " "
+  |> Str.global_replace str_timestamp "to_timestamp(XXX)"
+  |> String.trim
+
+class connection ~conninfo () =
+  object
+    method exec ?expect query =
+      Mock.catch ~conninfo @@ fun ~conninfo ->
+      let query = normalize query in
+      match Mock.pop ~conninfo with
+      | Expect f ->
+          let all = f ?expect query in
+          object
+            method get_all = all
+          end
+      | _ ->
+          Alcotest.fail
+            (Printf.sprintf "Postgreql.exec: unexpected exec %S" query)
+
+    method finish =
+      Mock.catch ~conninfo @@ fun ~conninfo ->
+      match Mock.pop ~conninfo with
+      | Expect_finish -> ()
+      | _ -> Alcotest.fail "Postgreql.exec: unexpected finish"
+  end

--- a/pipeline/tests/test.ml
+++ b/pipeline/tests/test.ml
@@ -1,1 +1,3 @@
-let () = Alcotest.run "pipeline" [ ("api", Api_test.tests) ]
+let () =
+  Alcotest.run "pipeline"
+    [ ("api", Api_test.tests); ("json_stream", Json_stream_test.tests) ]

--- a/pipeline/tests/test.ml
+++ b/pipeline/tests/test.ml
@@ -1,3 +1,4 @@
 let () =
-  Alcotest.run "pipeline"
-    [ ("api", Api_test.tests); ("json_stream", Json_stream_test.tests) ]
+  Lwt_main.run
+  @@ Alcotest_lwt.run "pipeline"
+       [ ("api", Api_test.tests); ("json_stream", Json_stream_test.tests) ]

--- a/pipeline/tests/test.ml
+++ b/pipeline/tests/test.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "pipeline" [ ("api", Api_test.tests) ]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /mnt/project
 
 # Build dependencies.
 COPY --chown=opam:opam cb-worker.opam cb-worker.opam
-RUN opam install -y --deps-only -t .
+RUN opam install -y --deps-only .
 COPY --chown=opam . .
 RUN sudo chown opam .
 


### PR DESCRIPTION
This is a WIP to add unit tests to parts of the pipeline. In its current state it's mostly a prototype to ease adding more tests in the future as I believe it would help a lot:

- I started by adding some unit tests for the new `api` since the code was still fresh in my mind. I discovered that I had missed during the review that tokens should be globally unique, which might cause some confusion if we treat tokens as passwords (?) Also I think that the unit tests could be simpler if the validation logic was not so dependent on Cohttp. @punchagan > Do you mind taking a look? :)

- Then I added some tests to the `Json_stream` parser since I already know it's not perfect... but this revealed an unexpected bug when the log output starts directly with a json. I plan to add a lot more tests to this module now!

- The main issue for writing unit tests is that we perform a lot of side effects (via ocurrent and postgresql), so I added a "mock" Postgresql module which allow the unit tests to simulate the sql server by specifying the expected queries and their outcome. I'm not yet satisfied with the sql "string" validation, so I'm open to any ideas!

In order to run the tests, you have to be inside the `pipeline/` directory and execute `dune runtest` or `dune exec tests/test.exe`. @gs0510 > Do you know if this something we could automatically run on new PR?

The overall idea is that the `tests/dune` imports the code from `pipeline/*.ml` so that the modules `tests/*_test.ml` can access the internal functions (that would otherwise be painful to expose in the `pipeline` library). This also allow us to "override" a library to mock it (see `tests/postgresql.ml` and the missing dependency to `postgresql` in `tests/dune`). I think we should be able to do something similar for modules that depend on ocurrent.