### PR TITLE
Fix benchmark name unique constraint

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -340,7 +340,9 @@ let make = () => {
   switch route {
   | Error({reason}) => <ErrorView msg={reason} />
   | Ok(Main) => <RepoView worker={None} />
-  | Ok(Repo({repoId, benchmarkName, worker})) => <RepoView repoId ?benchmarkName worker />
+  | Ok(Repo({repoId, benchmarkName, worker})) =>
+    let benchmarkName = Belt.Option.getWithDefault(benchmarkName, "default")
+    <RepoView repoId benchmarkName worker />
   | Ok(RepoPull({repoId, pullNumber, benchmarkName, worker})) =>
     <RepoView repoId pullNumber ?benchmarkName worker />
   }

--- a/frontend/src/Sidebar.res
+++ b/frontend/src/Sidebar.res
@@ -122,8 +122,9 @@ module SidebarMenu = {
     | Fetching => Rx.text("Loading...")
     | Data({benchmarksMenuData, pullsMenuData})
     | PartialData({benchmarksMenuData, pullsMenuData}, _) => <>
-      {
-        switch Belt.Array.some(benchmarksMenuData, bm => Belt.Option.isSome(bm.benchmark_name)) {
+        {switch Belt.Array.some(benchmarksMenuData, bm =>
+          Belt.Option.getWithDefault(bm.benchmark_name, "default") != "default"
+        ) {
         | true =>
           <Column>
             <Text color=Sx.gray700 weight=#bold uppercase=true size=#sm> "Benchmarks" </Text>

--- a/pipeline/db/migrations/20220203133132_set_benchmark_name_not_null.down.sql
+++ b/pipeline/db/migrations/20220203133132_set_benchmark_name_not_null.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE benchmarks ALTER COLUMN benchmark_name DROP NOT NULL;
+UPDATE benchmarks SET benchmark_name = NULL WHERE benchmark_name = 'default';

--- a/pipeline/db/migrations/20220203133132_set_benchmark_name_not_null.up.sql
+++ b/pipeline/db/migrations/20220203133132_set_benchmark_name_not_null.up.sql
@@ -1,0 +1,2 @@
+UPDATE benchmarks SET benchmark_name = 'default' WHERE benchmark_name IS NULL;
+ALTER TABLE benchmarks ALTER COLUMN benchmark_name SET NOT NULL;

--- a/pipeline/lib/models.ml
+++ b/pipeline/lib/models.ml
@@ -11,7 +11,7 @@ module Benchmark = struct
     run_job_id : string option;
     worker : string;
     docker_image : string;
-    benchmark_name : string option;
+    benchmark_name : string;
     test_name : string;
     test_index : int;
     metrics : Yojson.Safe.t;
@@ -21,6 +21,7 @@ module Benchmark = struct
       ~docker_image ~benchmark_name ~test_index ~repository data =
     let test_name = Yojson.Safe.Util.(member "name" data |> to_string) in
     let metrics = Yojson.Safe.Util.(member "metrics" data) in
+    let benchmark_name = Option.value ~default:"default" benchmark_name in
     {
       version;
       run_at;
@@ -84,7 +85,7 @@ module Benchmark = struct
         field "run_job_id" run_job_id Fmt.(option string);
         field "worker" worker Fmt.string;
         field "docker_image" docker_image Fmt.string;
-        field "benchmark_name" benchmark_name Fmt.(option string);
+        field "benchmark_name" benchmark_name Fmt.string;
         field "test_name" test_name Fmt.(string);
         field "test_index" test_index Fmt.(int);
         field "metrics" metrics Yojson.Safe.pp;
@@ -103,7 +104,7 @@ module Benchmark = struct
       let pull_number = Db_util.(option int) self.pull_number in
       let build_job_id = Db_util.(option string) self.build_job_id in
       let run_job_id = Db_util.(option string) self.run_job_id in
-      let benchmark_name = Db_util.(option string) self.benchmark_name in
+      let benchmark_name = Db_util.string self.benchmark_name in
       let test_name = Db_util.(string) self.test_name in
       let test_index = Db_util.(int) self.test_index in
       let metrics = Db_util.json self.metrics in

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -39,7 +39,7 @@ module Benchmark : sig
 
   val test_name : t -> string
 
-  val benchmark_name : t -> string option
+  val benchmark_name : t -> string
 
   val test_index : t -> int
 


### PR DESCRIPTION
c52c25a965a8a871f4c4a88f5894f2bb3ced4237 added a UNIQUE constraint
that includes the benchmark_name column. Postgres doesn't consider
NULL values to be equal and so the conflict on the UNIQUE constraint
with benchmark_name never gets triggered. 

This makes duplicate rows in the DB for the same metric, when we parse 
the JSON from the stream in multiple bits.

This PR has a couple of commits, one fixing the problem at the application level, and another to fix it at the DB level