### PR TITLE
Fix github status update: wait for benchmark to terminate

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -130,7 +130,8 @@ let pipeline ~ocluster ~conninfo ~repository env =
         Logs.err (fun log -> log "Error in %s stage: %s\n\n" stage m);
         Storage.record_stage_failure ~stage ~serial_id ~reason:m ~conninfo
     | _ -> ()
-  in
+  and+ () = ocluster_worker
+  and+ _ = output in
   ()
 
 let pipeline ~config ~ocluster ~conninfo ~repository =


### PR DESCRIPTION
A fix for production where benchmarks get a green "passed" flag on github, even when they are still running.

(see https://github.com/ocurrent/current-bench/issues/297 ... but I would like to keep this issue open until we have a way of checking that this bug will not reappear next time we touch the pipeline!)