### PR TITLE
Run DB migrations on pipeline start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ stop-production:
 .PHONY: redeploy-production
 redeploy-production: \
 	build-production \
-	run-migrations \
 	stop-production \
 	start-production
 
@@ -49,12 +48,6 @@ update-version-info:
 .PHONY: clean-local-test-repo
 clean-local-test-repo:
 	cd ./local-test-repo/ && rm -rf .git/
-
-.PHONY: run-migrations
-run-migrations:
-	docker exec -it current-bench_pipeline_1 omigrate up \
-		--verbose --source=/app/db/migrations \
-		--database=postgresql://docker:docker@db:5432/docker
 
 .PHONY: start-development
 start-development: ./local-test-repo/.git update-version-info validate-env

--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -98,6 +98,7 @@ services:
         condition: service_started
     environment:
       OCAML_BENCH_FRONTEND_URL: ${OCAML_BENCH_FRONTEND_URL?required}
+      OCAML_BENCH_DB_PASSWORD: ${OCAML_BENCH_DB_PASSWORD?required}
   cluster:
     build:
       context: ../cluster

--- a/environments/production.docker-compose.yaml
+++ b/environments/production.docker-compose.yaml
@@ -82,6 +82,7 @@ services:
         condition: service_started
     environment:
       OCAML_BENCH_FRONTEND_URL: ${OCAML_BENCH_FRONTEND_URL?required}
+      OCAML_BENCH_DB_PASSWORD: ${OCAML_BENCH_DB_PASSWORD?required}
   cluster:
     build:
       context: ../cluster

--- a/pipeline/entrypoint.sh
+++ b/pipeline/entrypoint.sh
@@ -22,4 +22,9 @@ USER=current-bench-pipeline
 # give permission to workers
 chmod -R a+rw /app/capnp-secrets
 
+# Run migrations
+set -eu
+echo "Running migrations..."
+omigrate up --verbose --source=/app/db/migrations --database="postgresql://docker:docker@db:5432/${OCAML_BENCH_DB_PASSWORD}"
+
 exec "$@"


### PR DESCRIPTION
We previously did this through a`make` target, but I think this is more robust, ensuring that the required DB migrations have been run for the current version of the app that we are going to start running. 