### PR TITLE
Show all commits for all metrics and highlight failed metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,3 +128,7 @@ coverage: ./local-test-repo/.git
 		'cd /mnt/project; opam exec -- dune runtest --instrument-with bisect_ppx --force; \
 		opam exec -- bisect-ppx-report summary --per-file; opam exec -- bisect-ppx-report html' \
 	&& echo "To view coverage html open file://${PWD}/pipeline/_coverage/index.html in your browser"
+
+.PHONY: local-make-bench
+local-make-bench: ./local-test-repo/.git
+	cd local-test-repo/; git add .; git commit --amend -m "New commit: $$(date)"; cd ..

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -108,10 +108,15 @@ module Benchmark = {
   @react.component
   let make = React.memo((~repoId, ~pullNumber, ~data: GetBenchmarks.t, ~lastCommit) => {
     let benchmarkDataByTestName = React.useMemo2(() => {
-      data.benchmarks->makeBenchmarkData->AdjustMetricUnit.adjust
+      data.benchmarks->makeBenchmarkData->AdjustMetricUnit.adjust->AppHelpers.fillMissingValues
     }, (data.benchmarks, makeBenchmarkData))
+
     let comparisonBenchmarkDataByTestName = React.useMemo2(
-      () => data.comparisonBenchmarks->Belt.Array.reverse->makeBenchmarkData,
+      () =>
+        data.comparisonBenchmarks
+        ->Belt.Array.reverse
+        ->makeBenchmarkData
+        ->AppHelpers.fillMissingValues,
       (data.comparisonBenchmarks, makeBenchmarkData),
     )
 

--- a/frontend/src/AppHelpers.res
+++ b/frontend/src/AppHelpers.res
@@ -15,3 +15,50 @@ let jobUrl = (~lines=?, jobId) => {
 }
 
 let defaultBenchmarkName = "default"
+
+// Get sorted (by runAt) metadata information for all commits
+let sortedMetadata = dataByTestName => {
+  dataByTestName
+  ->Belt.Map.String.valuesToArray
+  ->Belt.Array.map(((_, dataByMetricName)) => dataByMetricName->Belt.Map.String.valuesToArray)
+  ->Belt.Array.concatMany
+  ->Belt.Array.map(((_, md)) => md)
+  ->Belt.Array.concatMany
+  ->Belt.Array.reduce(Belt.Map.String.empty, (acc, md) => {
+    Belt.Map.String.set(acc, md["commit"], md)
+  })
+  ->Belt.Map.String.valuesToArray
+  ->Belt.SortArray.stableSortBy((a, b) =>
+    compare(Js.Date.getTime(a["runAt"]), Js.Date.getTime(b["runAt"]))
+  )
+}
+
+// Fill in NaN values and add missing commit metadata
+let addMissingCommits = ((metricTimeseries, metricMetadata), allCommits) => {
+  let n = Belt.Array.length(allCommits)
+  switch Belt.Array.length(metricTimeseries) < n {
+  | false => metricTimeseries
+  | true => {
+      let missingValue = [Js.Float._NaN, Js.Float._NaN, Js.Float._NaN]
+      let filledTimeseries = allCommits->Belt.Array.map(commit =>
+        switch metricMetadata->Belt.Array.getIndexBy(md => md["commit"] == commit) {
+        | Some(idx) => Belt.Array.getExn(metricTimeseries, idx)
+        | None => missingValue
+        }
+      )
+      filledTimeseries
+    }
+  }
+}
+
+// Fill in values and metadata for all missing commits across all metrics in all tests
+let fillMissingValues = dataByTestName => {
+  let allMetadata = sortedMetadata(dataByTestName)
+  let allCommits = allMetadata->Belt.Array.map(md => md["commit"])
+  dataByTestName->Belt.Map.String.map(((test_index, dataByMetricName)) => (
+    test_index,
+    dataByMetricName->Belt.Map.String.map(metricData => {
+      (addMissingCommits(metricData, allCommits), allMetadata)
+    }),
+  ))
+}

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -265,7 +265,6 @@ let make = (
       let units = (mergedMetadata->BeltHelpers.Array.lastExn)["units"]
       let lines = (mergedMetadata->BeltHelpers.Array.lastExn)["lines"]
       let run_job_id = (mergedMetadata->BeltHelpers.Array.lastExn)["run_job_id"]
-      let dataSet = tsArrays->Belt.Array.map(ts => ts->Belt.Array.sliceToEnd(-20))
       let labels = suffixes
       let firstPullX = Belt.Array.length(comparisonTimeseries)
       let annotations =
@@ -291,7 +290,7 @@ let make = (
           title
           subTitle
           xTicks
-          dataSet
+          dataSet=tsArrays
           units
           annotations
           labels

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -321,11 +321,7 @@ let make = (
       <Text sx=[Sx.w.auto, Sx.text.md, Sx.text.bold, Sx.text.color(Sx.gray900)]> testName </Text>
     </summary>
     {Belt.Map.String.isEmpty(comparison) ? Rx.null : metric_table}
-    <div
-      className={Sx.make([
-        Sx.unsafe("display", "grid"),
-        Sx.unsafe("gap", "2px"),
-      ])}>
+    <div className={Sx.make([Sx.unsafe("display", "grid"), Sx.unsafe("gap", "2px")])}>
       metric_graphs
     </div>
   </details>

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -280,13 +280,13 @@ let make = (
         }
       )
 
-      let onXLabelClick = AppHelpers.goToCommitLink(~repoId)
+      let goToCommit = AppHelpers.goToCommitLink(~repoId)
       let id = `line-graph-${testName}-${title}`
 
       <div key=metricName className={Sx.make(oldMetrics ? [Sx.opacity25] : [])}>
         {Topbar.anchor(~id)}
         <LineGraph
-          onXLabelClick
+          goToCommit
           title
           subTitle
           xTicks

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -325,8 +325,7 @@ let make = (
     <div
       className={Sx.make([
         Sx.unsafe("display", "grid"),
-        Sx.unsafe("gap", "32px"), // xl2
-        Sx.unsafe("gridTemplateColumns", "repeat(auto-fit, minmax(400px, 1fr))"),
+        Sx.unsafe("gap", "2px"),
       ])}>
       metric_graphs
     </div>

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -250,7 +250,7 @@ let make = (
         m,
         index,
       ) => {
-        Belt.Map.Int.set(acc, index, DataHelpers.trimCommit(m["commit"]))
+        Belt.Map.Int.set(acc, index, m["commit"])
       })
       let rows =
         seriesArrays->Belt.Array.map(((ts, md, comp_ts, comp_md)) =>

--- a/frontend/src/CommitInfo.res
+++ b/frontend/src/CommitInfo.res
@@ -149,17 +149,12 @@ let make = (~repoId, ~pullNumber=?, ~benchmarks: GetBenchmarks.t, ~worker, ~setL
   | Data(data)
   | PartialData(data, _) =>
     let lastCommitInfo = data.lastCommitInfo[0]
-    let lastBenchmark = Belt.Array.get(
-      benchmarks,
-      Belt.Array.length(benchmarks) - 1,
-    )
-    let (lastCommit, lastBenchmark) =
-      switch lastBenchmark {
-        | Some (lastBenchmark) when lastBenchmark.commit != lastCommitInfo.commit =>
-          (lastBenchmark.commit, Some(lastBenchmark.commit))
-        | _ => (lastCommitInfo.commit, None)
-      }
-    setLastCommit(Some(lastCommit))
+    let lastBenchmark = Belt.Array.get(benchmarks, Belt.Array.length(benchmarks) - 1)
+    let lastBenchmarkCommit = switch lastBenchmark {
+    | Some(lastBenchmark) => Some(lastBenchmark.commit)
+    | _ => None
+    }
+    setLastCommit(Some(lastCommitInfo.commit))
     let sameBuildJobLog = switch (lastCommitInfo.build_job_id, lastCommitInfo.run_job_id) {
     | (Some(buildID), Some(jobID)) => buildID == jobID
     | (_, _) => false
@@ -231,9 +226,8 @@ let make = (~repoId, ~pullNumber=?, ~benchmarks: GetBenchmarks.t, ~worker, ~setL
 
         </Column>
       </Row>
-      {switch (status, lastBenchmark) {
-      | (Fail | Cancel | Running, Some(benchmark)) =>
-        <>
+      {switch (status, lastBenchmarkCommit) {
+      | (Fail | Cancel | Running, Some(benchmark)) => <>
           <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.yellow600)]>
             "Metrics for an older commit "
           </Text>

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -457,23 +457,30 @@ let make = React.memo((
   let left = switch title {
   | Some(title) =>
     <Column spacing=Sx.lg sx=[Sx.w.auto]>
-      <div className={Sx.make([Sx.d.flex, Sx.flex.row])}>
-        <Text sx=[Sx.leadingNone, Sx.text.bold, Sx.text.md]> title </Text>
+      <div className={Sx.make([Sx.d.flex, Sx.flex.row, Sx.items.baseline])}>
+        <Text sx=[Sx.leadingNone, Sx.text.bold, Sx.text.md, Sx.mr.md]> title </Text>
+        {switch subTitle {
+        | String(text) =>
+          <Text
+            sx=[
+              Sx.leadingNone,
+              Sx.text.sm,
+              Sx.text.color(Sx.gray600),
+              [Css.minHeight(#em(1.0))],
+              Sx.mr.md,
+            ]>
+            {text}
+          </Text>
+        | Element(elem) => elem
+        }}
         {switch (run_job_id, lines->Belt.List.get(0)) {
         | (Some(jobId), Some(lines)) =>
           <a target="_blank" href={jobUrl(jobId, ~lines)}>
-            {<Icon sx=[Sx.unsafe("width", "12px"), Sx.ml.md] svg=Icon.help />}
+            {<Icon sx=[Sx.unsafe("width", "12px")] svg=Icon.help />}
           </a>
         | _ => Rx.null
         }}
       </div>
-      {switch subTitle {
-      | String(text) =>
-        <Text sx=[Sx.leadingNone, Sx.text.sm, Sx.text.color(Sx.gray600), [Css.minHeight(#em(1.0))]]>
-          {text}
-        </Text>
-      | Element(elem) => elem
-      }}
     </Column>
   | None => React.null
   }

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -458,7 +458,7 @@ let make = React.memo((
   | Some(title) =>
     <Column spacing=Sx.lg sx=[Sx.w.auto]>
       <div className={Sx.make([Sx.d.flex, Sx.flex.row])}>
-        <Text sx=[Sx.leadingNone, Sx.text.bold, Sx.text.xl]> title </Text>
+        <Text sx=[Sx.leadingNone, Sx.text.bold, Sx.text.md]> title </Text>
         {switch (run_job_id, lines->Belt.List.get(0)) {
         | (Some(jobId), Some(lines)) =>
           <a target="_blank" href={jobUrl(jobId, ~lines)}>
@@ -529,10 +529,10 @@ let make = React.memo((
         ->Rx.array(~empty=<Message text="No labels" />)}
       </Row>
     : <Row alignX=#right spacing=Sx.md sx=[Sx.w.auto]>
-        <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray900)]>
+        <Text sx=[Sx.leadingNone, Sx.text.md, Sx.text.bold, Sx.text.color(Sx.gray900)]>
           {lastValues->BeltHelpers.Array.lastExn}
         </Text>
-        <Text sx=[Sx.leadingNone, Sx.text.xl2, Sx.text.bold, Sx.text.color(Sx.gray500)]>
+        <Text sx=[Sx.leadingNone, Sx.text.md, Sx.text.bold, Sx.text.color(Sx.gray500)]>
           units
         </Text>
       </Row>

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -133,7 +133,7 @@ module Legend = {
     let statsIndex = Array.length(data.series) / 2
     switch xLabel {
     | Some(xLabel) =>
-      let html = "<b>" ++ xLabel ++ "</b>"
+      let html = "<b>" ++ DataHelpers.trimCommit(xLabel) ++ "</b>"
       let row = (dashHTML, labelHTML, yHTML) => {
         "<div class='dygraph-legend-row'>" ++
         (dashHTML ++

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -379,11 +379,23 @@ let make = React.memo((
     )
   }
 
+  let onClick = (_e, point) => {
+    let commit = switch xTicks {
+    | Some(xTicks) => xTicks->Belt.Map.Int.get(point["idx"])
+    | _ => None
+    }
+    switch (commit, goToCommit) {
+    | (Some(commit), Some(goToCommit)) => goToCommit(commit)
+    | _ => ()
+    }
+  }
+
   React.useEffect1(() => {
     let options = defaultOptions(
       ~yLabel?,
       ~labels?,
       ~xTicks?,
+      ~onClick,
       ~legendFormatter=Legend.format(~xTicks?),
       (),
     )
@@ -435,6 +447,7 @@ let make = React.memo((
           ~yLabel?,
           ~labels?,
           ~xTicks?,
+          ~onClick,
           ~data=makeDygraphData(dataSet),
           ~legendFormatter=Legend.format(~xTicks?),
           (),

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -496,6 +496,7 @@ let make = React.memo((
             ->Belt.Option.getWithDefault("#000000")
             ->Js.String2.substr(~from=1)
           <div
+            key={idx->Belt.Int.toString}
             className={Sx.make([
               Sx.d.inlineFlex,
               Sx.items.center,

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -280,7 +280,7 @@ Sx.global(".dygraph-axis-label-y", [Sx.pr.sm])
 
 Sx.global(".dygraph-axis-label", [Sx.text.xs, Sx.z.high, Sx.overflow.hidden, Sx.opacity75])
 
-let graphSx = [Sx.unsafe("height", "190px")]
+let graphSx = [Sx.unsafe("height", "150px")]
 
 let containerSxBase = [Sx.w.full, Sx.rounded.md, Sx.p.lg]
 let containerSxFailed = Belt.Array.concat(

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -110,12 +110,6 @@ let getElementsByClassName: string => array<Dom.element> = %raw(`
   }
 `)
 
-let getElementHTMLonClick: (Dom.element, string => unit) => unit = %raw(`
-  function(elem, handler) {
-    elem.onclick = function(e) { handler(e.target.innerHTML) }
-  }
-`)
-
 module Legend = {
   type t = {
     label: string,
@@ -190,7 +184,6 @@ let defaultOptions = (
   ~labels=?,
   ~onClick=?,
   ~data=[],
-  ~xLabelFormatter=?,
   (),
 ) => {
   let ticker = {
@@ -215,10 +208,8 @@ let defaultOptions = (
     "axes": {
       "x": {
         "drawGrid": true,
-        "drawAxis": true,
-        "axisLabelFormatter": Js.Null.fromOption(xLabelFormatter),
+        "drawAxis": false,
         "ticker": ticker,
-        "axisLabelWidth": 45,
       },
       "y": {
         "drawAxis": true,
@@ -289,7 +280,7 @@ Sx.global(".dygraph-axis-label-y", [Sx.pr.sm])
 
 Sx.global(".dygraph-axis-label", [Sx.text.xs, Sx.z.high, Sx.overflow.hidden, Sx.opacity75])
 
-let graphSx = [Sx.unsafe("height", "190px"), Sx.unsafe("marginBottom", "40px")]
+let graphSx = [Sx.unsafe("height", "190px")]
 
 let containerSxBase = [Sx.w.full, Sx.rounded.md, Sx.p.lg]
 let containerSxFailed = Belt.Array.concat(
@@ -414,14 +405,6 @@ let make = React.memo((
               graph->setAnnotations(annotations)
             })
           }
-
-          switch goToCommit {
-          | Some(handler) =>
-            getElementsByClassName("dygraph-axis-label-x")->Belt.Array.forEach(elem =>
-              getElementHTMLonClick(elem, handler)
-            )
-          | None => ()
-          }
         }
       | _ => ()
       }
@@ -454,14 +437,6 @@ let make = React.memo((
         )
         graph->updateOptions(options)
         graph->setAnnotations(annotations)
-
-        switch goToCommit {
-        | Some(handler) =>
-          getElementsByClassName("dygraph-axis-label-x")->Belt.Array.forEach(elem =>
-            getElementHTMLonClick(elem, handler)
-          )
-        | None => ()
-        }
       }
     }
     None

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -291,7 +291,7 @@ Sx.global(".dygraph-axis-label", [Sx.text.xs, Sx.z.high, Sx.overflow.hidden, Sx.
 
 let graphSx = [Sx.unsafe("height", "190px"), Sx.unsafe("marginBottom", "40px")]
 
-let containerSxBase = [Sx.w.full, Sx.rounded.md, Sx.p.xl]
+let containerSxBase = [Sx.w.full, Sx.rounded.md, Sx.p.lg]
 let containerSxFailed = Belt.Array.concat(
   containerSxBase,
   [Sx.border.color(Sx.red300), Sx.border.md],
@@ -540,7 +540,7 @@ let make = React.memo((
   let sx = Array.append(uSx, failedMetric ? containerSxFailed : containerSx)
 
   <div className={Sx.make(sx)}>
-    <Row spacing=#between alignY=#top sx={[Sx.mb.xl]}> {left} {right} </Row>
+    <Row spacing=#between alignY=#top sx={[Sx.mb.lg]}> {left} {right} </Row>
     <div className={Sx.make(graphSx)} ref={ReactDOM.Ref.domRef(graphDivRef)} />
   </div>
 })

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -312,7 +312,7 @@ let make = React.memo((
   ~xTicks: option<Belt.Map.Int.t<string>>=?,
   ~yLabel: option<string>=?,
   ~labels: option<array<string>>=?,
-  ~onXLabelClick=?,
+  ~goToCommit=?,
   ~annotations: array<{
     "clickHandler": (annotation, point, graph, event) => unit,
     "height": int,
@@ -403,7 +403,7 @@ let make = React.memo((
             })
           }
 
-          switch onXLabelClick {
+          switch goToCommit {
           | Some(handler) =>
             getElementsByClassName("dygraph-axis-label-x")->Belt.Array.forEach(elem =>
               getElementHTMLonClick(elem, handler)
@@ -442,7 +442,7 @@ let make = React.memo((
         graph->updateOptions(options)
         graph->setAnnotations(annotations)
 
-        switch onXLabelClick {
+        switch goToCommit {
         | Some(handler) =>
           getElementsByClassName("dygraph-axis-label-x")->Belt.Array.forEach(elem =>
             getElementHTMLonClick(elem, handler)


### PR DESCRIPTION
- To "align" the metrics for catching spikes and regressions visually, we show all the commits for all the metrics.
- Metrics that don't have a value for the latest commit are treated as failed commits.

*Edit*: Adding a screenshot

![image](https://user-images.githubusercontent.com/315678/154966397-ee4ae6f8-f62a-4429-8539-669d274d3719.png)


Additionally, this PR also has a couple of other bug fixes. 

- Fix React warnings about missing  `key`
- Fix bug with marking metrics as old metrics