### PR TITLE
Slack

### DIFF
--- a/current-bench.opam
+++ b/current-bench.opam
@@ -20,6 +20,7 @@ depends: [
   "current_git"    {= "dev"}
   "current_github" {= "dev"}
   "current_rpc"    {= "dev"}
+  "current_slack"  {= "dev"}
   "current_web"    {= "dev"}
   "current_incr" {>= "0.5"}
   "current_ansi"
@@ -46,6 +47,7 @@ pin-depends: [
   [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
   [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
   [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
+  [ "current_slack.dev"  "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
   [ "current_web.dev"    "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
   [ "current_ocluster.dev" "git+https://github.com/art-w/ocluster.git#f5884b0e8454c29c156cda939416436565206e24" ]
   [ "ocluster-api.dev"     "git+https://github.com/art-w/ocluster.git#f5884b0e8454c29c156cda939416436565206e24" ]

--- a/environments/development.conf
+++ b/environments/development.conf
@@ -2,10 +2,12 @@
   "repositories": [
     {
       "name": "local/local",
+      "worker": "autumn",
       "image": "ocaml/opam:debian-11-ocaml-4.14"
     },
     {
       "name": "local/local",
+      "worker": "autumn",
       "image": "ocaml/opam:debian-11-ocaml-4.13"
     }
   ],

--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -90,6 +90,8 @@ services:
       - "--github-account-allowlist=${OCAML_BENCH_GITHUB_ACCOUNT_ALLOW_LIST}"
       - "--github-private-key-file=/mnt/environments/${OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE}"
       - "--github-webhook-secret-file=/mnt/environments/${OCAML_BENCH_GITHUB_WEBHOOK_SECRET_FILE}"
+      - "--frontend-url=${OCAML_BENCH_FRONTEND_URL?required}"
+      - "--pipeline-url=${OCAML_BENCH_PIPELINE_URL?required}"
     restart: always
     depends_on:
       db:

--- a/environments/production.docker-compose.yaml
+++ b/environments/production.docker-compose.yaml
@@ -74,6 +74,8 @@ services:
       - "--github-account-allowlist=${OCAML_BENCH_GITHUB_ACCOUNT_ALLOW_LIST?required}"
       - "--github-private-key-file=${OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE?required}"
       - "--github-webhook-secret-file=${OCAML_BENCH_GITHUB_WEBHOOK_SECRET_FILE?required}"
+      - "--frontend-url=${OCAML_BENCH_FRONTEND_URL?required}"
+      - "--pipeline-url=${OCAML_BENCH_PIPELINE_URL?required}"
     restart: always
     depends_on:
       db:

--- a/frontend/src/AppRouter.res
+++ b/frontend/src/AppRouter.res
@@ -14,7 +14,7 @@ let parseParams = (query) => {
   Js.String.split("&", query)
   ->Belt.Array.keepMap((part) => {
       switch Js.String.split("=", part) {
-        | [ key, value ] => Some((key, Js.Global.decodeURI(value)))
+        | [ key, value ] => Some((key, Js.Global.decodeURIComponent(value)))
         | _ => None
       }
   })
@@ -75,7 +75,7 @@ let workerParams = (worker) =>
   switch worker {
     | None => ""
     | Some((worker, dockerImage)) =>
-      "?worker=" ++ Js.Global.encodeURI(worker) ++ "&image=" ++ Js.Global.encodeURI(dockerImage)
+      "?worker=" ++ Js.Global.encodeURIComponent(worker) ++ "&image=" ++ Js.Global.encodeURIComponent(dockerImage)
   }
 
 let path = route =>

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -2,17 +2,17 @@ FROM ocaml/opam:debian-11-ocaml-4.13 AS build
 
 RUN sudo apt-get update && \
     sudo apt-get install -qq -yy \
-    libffi-dev \
-    m4 \
     pkg-config \
+    m4 \
     libssl-dev \
-    libgmp-dev \
-    libpq-dev \
-    graphviz \
-    capnproto \
     libsqlite3-dev \
+    libpq-dev \
+    libgmp-dev \
+    libffi-dev \
+    libev-dev \
     libcapnp-dev \
-    libev-dev
+    graphviz \
+    capnproto
 
 RUN opam remote add origin 'https://opam.ocaml.org' --all-switches && opam remote remove default && opam update
 

--- a/pipeline/Dockerfile.dev
+++ b/pipeline/Dockerfile.dev
@@ -2,17 +2,17 @@ FROM ocaml/opam:debian-11-ocaml-4.13 AS build
 
 RUN sudo apt-get update && \
     sudo apt-get install -qq -yy \
-    libffi-dev \
-    m4 \
     pkg-config \
+    m4 \
     libssl-dev \
-    libgmp-dev \
-    libpq-dev \
-    graphviz \
-    capnproto \
     libsqlite3-dev \
+    libpq-dev \
+    libgmp-dev \
+    libffi-dev \
+    libev-dev \
     libcapnp-dev \
-    libev-dev
+    graphviz \
+    capnproto
 
 RUN opam remote add origin 'https://opam.ocaml.org' --all-switches && opam remote remove default && opam update
 

--- a/pipeline/bin/main.ml
+++ b/pipeline/bin/main.ml
@@ -112,6 +112,16 @@ let conninfo =
   @@ Arg.info ~doc:"Connection info for Postgres DB" ~docv:"PATH"
        [ "conn-info" ]
 
+let frontend_url =
+  Arg.required
+  @@ Arg.opt Arg.(some string) None
+  @@ Arg.info ~doc:"URL of the frontend" ~docv:"URL" [ "frontend-url" ]
+
+let pipeline_url =
+  Arg.required
+  @@ Arg.opt Arg.(some string) None
+  @@ Arg.info ~doc:"URL of the ocurrent pipeline" ~docv:"URL" [ "pipeline-url" ]
+
 let config_file =
   let arg =
     Arg.required
@@ -119,7 +129,12 @@ let config_file =
     @@ Arg.info ~doc:"Config file for repositories" ~docv:"PATH"
          [ "repositories" ]
   in
-  Term.(const Pipeline.Config.of_file $ arg)
+  Term.(
+    const (fun frontend_url pipeline_url config_file ->
+        Pipeline.Config.of_file ~frontend_url ~pipeline_url config_file)
+    $ frontend_url
+    $ pipeline_url
+    $ arg)
 
 let cmd : (unit, string) result Term.t =
   Term.(

--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -1,4 +1,5 @@
 module Docker = Current_docker.Default
+module Slack = Current_slack
 module Images = Map.Make (String)
 
 let default_worker = "autumn"
@@ -15,10 +16,20 @@ type repo_list = repo list [@@deriving yojson]
 type api_token = { repo : string; token : string } [@@deriving yojson]
 type api_token_list = api_token list [@@deriving yojson]
 
+type config = {
+  repositories : repo_list;
+  api_tokens : api_token_list;
+  slack : (string option[@default None]);
+}
+[@@deriving yojson]
+
 type t = {
   repos : repo_list;
   images : Docker.Image.t Current.t Images.t;
   api_tokens : api_token_list;
+  slack : Slack.channel option;
+  frontend_url : string;
+  pipeline_url : string;
 }
 
 let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
@@ -38,22 +49,23 @@ let make_images repos =
     (pull default_docker Images.empty)
     repos
 
-let make repos tokens =
-  { repos; images = make_images repos; api_tokens = tokens }
+let slack_of_url = function
+  | None -> None
+  | Some url -> Some (Slack.channel (Uri.of_string url))
 
-let of_file filename : t =
+let of_file ~frontend_url ~pipeline_url filename : t =
   let filename = Fpath.to_string filename in
   let json = Yojson.Safe.from_file filename in
-  let repositories = Yojson.Safe.Util.(member "repositories" json) in
-  let api_tokens = Yojson.Safe.Util.(member "api_tokens" json) in
-  let tokens =
-    match api_token_list_of_yojson api_tokens with
-    | Ok tokens -> tokens
-    | Error err ->
-        failwith (Printf.sprintf "Config.of_file %S : %s" filename err)
-  in
-  match repo_list_of_yojson repositories with
-  | Ok repos -> make repos tokens
+  match config_of_yojson json with
+  | Ok { repositories; api_tokens; slack } ->
+      {
+        repos = repositories;
+        api_tokens;
+        images = make_images repositories;
+        slack = slack_of_url slack;
+        frontend_url;
+        pipeline_url;
+      }
   | Error err -> failwith (Printf.sprintf "Config.of_file %S : %s" filename err)
 
 let find t name =
@@ -62,3 +74,34 @@ let find t name =
   | configs -> configs
 
 let find_image t image_name = Images.find image_name t.images
+
+let repo_url ~config repo worker docker_image =
+  Printf.sprintf "%s/%s?worker=%s&image=%s" config.frontend_url
+    (Repository.to_path repo) (Uri.pct_encode worker)
+    (Uri.pct_encode docker_image)
+
+let job_url ~config job_id start stop =
+  Printf.sprintf "%s/job/%s#L%i-L%i" config.pipeline_url job_id start stop
+
+let key_of_repo ~config repository worker docker_image =
+  Printf.sprintf "<%s|*%s* _%s_ %s>"
+    (repo_url ~config repository worker docker_image)
+    (Repository.to_string repository)
+    worker docker_image
+
+let slack_log ~config ~key msg =
+  match config.slack with
+  | None -> Current.ignore_value msg
+  | Some channel ->
+      Logs.err (fun log -> log "slack_post? %s" key);
+      let msg =
+        let open Current.Syntax in
+        let+ state = Current.catch ~hidden:true msg in
+        let icon, msg =
+          match state with
+          | Ok msg -> (":heavy_check_mark:", msg)
+          | Error (`Msg e) -> (":x: <!here>", "*`" ^ e ^ "`*")
+        in
+        icon ^ " " ^ key ^ ": " ^ msg
+      in
+      Slack.post channel ~key msg

--- a/pipeline/lib/current_bench_json.ml
+++ b/pipeline/lib/current_bench_json.ml
@@ -277,6 +277,13 @@ let of_json json = Latest.of_json json
 let of_list jsons =
   List.fold_left (fun acc json -> Latest.merge acc [ of_json json ]) [] jsons
 
+let to_json { Latest.benchmark_name; results } : Json.t =
+  let name = match benchmark_name with None -> `Null | Some s -> `String s in
+  `Assoc
+    [
+      ("name", name); ("results", `List (List.map Latest.json_of_result results));
+    ]
+
 let to_list ts =
   List.map
     (fun { Latest.benchmark_name; results } ->

--- a/pipeline/lib/dune
+++ b/pipeline/lib/dune
@@ -2,7 +2,7 @@
  (name pipeline)
  (public_name pipeline)
  (libraries current current.fs current_docker current_git current_github
-   current_ocluster capnp-rpc-unix current_web dockerfile fmt.tty logs
-   logs.fmt prometheus rresult uri postgresql yojson str)
+   current_ocluster capnp-rpc-unix current_web current_slack dockerfile
+   fmt.tty logs logs.fmt prometheus rresult uri postgresql yojson str)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/pipeline/lib/pipeline.mli
+++ b/pipeline/lib/pipeline.mli
@@ -4,7 +4,7 @@ module Github = Current_github
 module Config : sig
   type t
 
-  val of_file : Fpath.t -> t
+  val of_file : frontend_url:string -> pipeline_url:string -> Fpath.t -> t
 end
 
 module Source : sig

--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -37,6 +37,24 @@ let branch t = t.branch
 let github_head t = t.github_head
 let id t = (t.owner, t.name)
 let info t = t.owner ^ "/" ^ t.name
+
+let to_string t =
+  let pr =
+    match t.pull_number with None -> "" | Some pr -> " #" ^ string_of_int pr
+  in
+  let br = match t.branch with None -> "" | Some br -> " " ^ br in
+  let hash = Current_git.Commit_id.hash t.commit in
+  let hash = String.sub hash 0 6 in
+  info t ^ br ^ pr ^ " `" ^ hash ^ "`"
+
+let to_path t =
+  let pr =
+    match t.pull_number with
+    | None -> ""
+    | Some pr -> "/pull/" ^ string_of_int pr
+  in
+  info t ^ pr
+
 let frontend_url () = Sys.getenv "OCAML_BENCH_FRONTEND_URL"
 
 (* $server/$repo_owner/$repo_name/pull/$pull_number *)

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -20,6 +20,7 @@ depends: [
   "current_git"    {= "dev"}
   "current_github" {= "dev"}
   "current_rpc"    {= "dev"}
+  "current_slack"  {= "dev"}
   "current_web"    {= "dev"}
   "current_incr" {>= "0.5"}
   "current_ansi"
@@ -39,6 +40,7 @@ pin-depends: [
   [ "current_github.dev" "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
   [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
   [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
+  [ "current_slack.dev"  "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
   [ "current_web.dev"    "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]
 ]
 build: [

--- a/pipeline/tests/dune
+++ b/pipeline/tests/dune
@@ -2,7 +2,8 @@
  (name test)
  (libraries alcotest alcotest-lwt current current.fs current_docker
    current_git current_github current_ocluster capnp-rpc-unix current_web
-   dockerfile fmt.tty logs logs.fmt prometheus rresult uri yojson str)
+   current_slack dockerfile fmt.tty logs logs.fmt prometheus rresult uri
+   yojson str)
  (preprocess
   (pps ppx_deriving_yojson))
  (instrumentation


### PR DESCRIPTION
This PR sends debug logs to a (private) slack channel, to watch what is happening in production:

![slack_screenshot](https://user-images.githubusercontent.com/4807590/156171822-c6dc3017-fdc5-4692-a70d-a381a7c8e7f1.png)

It will also trigger an `@here` mention in case of an unexpected failure:

![slack_mention](https://user-images.githubusercontent.com/4807590/156172768-4ca3dccb-f655-4210-a063-8d0db39dec64.png)

Before releasing it to production, we'll need to edit the `production.conf` to add a slack channel "incoming webhook":

```json
{
  "slack": "https://hooks.slack.com/services/...",
  "repositories": [ /* ... */ ],
  "api_tokens": [ /* ... */ ]
}
```
(Of course you can also create your own dev slack app and send your logs by configuring `development.conf`)