### PR TITLE
Add a Cobench client library for pushing results with the http api

### DIFF
--- a/cobench.opam
+++ b/cobench.opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Continuous benchmarks library for Current-Bench"
+maintainer: ["Arthur Wendling <arthur@tarides.com>" "Gargi Sharma <gargi@tarides.com>" "Puneeth Chaganti <puneeth@tarides.com>"]
+authors: ["Arthur Wendling <arthur@tarides.com>" "Gargi Sharma <gargi@tarides.com>" "Puneeth Chaganti <puneeth@tarides.com>"]
+homepage: "https://github.com/ocurrent/current-bench"
+bug-reports: "https://github.com/ocurrent/current-bench/issues"
+dev-repo: "git+https://github.com/ocurrent/current-bench.git"
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune"  {>= "2.0"}
+  "yojson"
+  "cohttp-lwt-unix"
+  "odoc" {with-doc}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+available: [ os-distribution != "alpine" ]

--- a/cobench/cobench.ml
+++ b/cobench/cobench.ml
@@ -20,6 +20,7 @@ type t = L.t
 
 let of_results results = { L.benchmark_name = None; results }
 let to_json = C.to_json
+let of_json = C.of_json
 
 module Remote = struct
   type token = {

--- a/cobench/cobench.ml
+++ b/cobench/cobench.ml
@@ -1,0 +1,84 @@
+module C = Current_bench_json
+module L = C.Latest
+module J = Yojson.Safe
+
+type value = L.value
+
+let single v = L.Float v
+let list vs = L.Floats vs
+
+type metric = L.metric
+
+let metric ~name ?(description = "") ?(units = "") ?(trend = "") value =
+  { L.name; description; units; trend; value; lines = [] }
+
+type result = L.result
+
+let of_metrics ~name ms = { L.test_name = name; metrics = ms }
+
+type t = L.t
+
+let of_results results = { L.benchmark_name = None; results }
+let to_json = C.to_json
+
+module Remote = struct
+  type token = {
+    url : Uri.t;
+    repo_owner : string;
+    repo_name : string;
+    password : string;
+  }
+
+  let token ?(url = "https://autumn.ocamllabs.io/benchmarks/metrics") ~owner
+      ~repo ~password () =
+    { url = Uri.of_string url; repo_owner = owner; repo_name = repo; password }
+
+  type branch = Branch of string | Pull_number of int
+
+  let json_of_branch = function
+    | Branch br -> ("branch", `String br)
+    | Pull_number pr -> ("pull_number", `Int pr)
+
+  let json_of_ptime date =
+    let date =
+      match date with Some date -> date | None -> Ptime_clock.now ()
+    in
+    `String (Ptime.to_rfc3339 date)
+
+  let json_of_duration = function
+    | None -> []
+    | Some d -> [ ("duration", `String (string_of_float d)) ]
+
+  let push ~token ~branch ~commit ?date ?duration (benchmarks : t) =
+    let json =
+      `Assoc
+        ([
+           ("repo_owner", `String token.repo_owner);
+           ("repo_name", `String token.repo_name);
+           json_of_branch branch;
+           ("commit", `String commit);
+           ("run_at", json_of_ptime date);
+           ("benchmarks", `List [ to_json benchmarks ]);
+         ]
+        @ json_of_duration duration)
+    in
+    let body = J.to_string json in
+    let body = Cohttp_lwt__Body.of_string body in
+    let headers =
+      Cohttp.Header.of_list
+        [
+          ("Content-Type", "application/json");
+          ("Authorization", "Bearer " ^ token.password);
+        ]
+    in
+    let open Lwt.Syntax in
+    let* _, body = Cohttp_lwt_unix.Client.post ~headers ~body token.url in
+    let* body = Cohttp_lwt.Body.to_string body in
+    let json = J.from_string body in
+    let success = J.Util.member "success" json in
+    let error = try J.Util.member "error" json with _ -> `Null in
+    match (success, error) with
+    | `Bool true, `Null -> Lwt.return_unit
+    | `Bool false, `String msg -> Lwt.fail_with msg
+    | _ -> Lwt.fail_with (J.to_string json)
+end

--- a/cobench/cobench.mli
+++ b/cobench/cobench.mli
@@ -1,0 +1,46 @@
+type value
+
+val single : float -> value
+val list : float list -> value
+
+type metric
+
+val metric :
+  name:string ->
+  ?description:string ->
+  ?units:string ->
+  ?trend:string ->
+  value ->
+  metric
+
+type result
+
+val of_metrics : name:string -> metric list -> result
+
+type t
+
+val of_results : result list -> t
+val to_json : t -> Yojson.Safe.t
+
+module Remote : sig
+  type token
+
+  val token :
+    ?url:string ->
+    owner:string ->
+    repo:string ->
+    password:string ->
+    unit ->
+    token
+
+  type branch = Branch of string | Pull_number of int
+
+  val push :
+    token:token ->
+    branch:branch ->
+    commit:string ->
+    ?date:Ptime.t ->
+    ?duration:float ->
+    t ->
+    unit Lwt.t
+end

--- a/cobench/cobench.mli
+++ b/cobench/cobench.mli
@@ -21,6 +21,7 @@ type t
 
 val of_results : result list -> t
 val to_json : t -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> t
 
 module Remote : sig
   type token

--- a/cobench/dune
+++ b/cobench/dune
@@ -1,0 +1,6 @@
+(library
+ (public_name cobench)
+ (libraries lwt cohttp-lwt-unix yojson ptime))
+
+(rule
+ (copy ../pipeline/lib/current_bench_json.ml current_bench_json.ml))

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -31,7 +31,6 @@ depends: [
   "duration"
   "fpath"
   "logs"
-  "ocaml" {>= "4.08"}
   "postgresql"
   "rresult"
   "omigrate"

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,8 @@
-pipeline/dune-project
+(lang dune 2.0)
+(name current-bench)
+
+(package
+  (name current-bench))
+
+(package
+  (name cobench))

--- a/pipeline/dune-project
+++ b/pipeline/dune-project
@@ -1,3 +1,2 @@
 (lang dune 2.0)
 (name pipeline)
-

--- a/pipeline/lib/current_bench_json.ml
+++ b/pipeline/lib/current_bench_json.ml
@@ -267,12 +267,21 @@ module V2 = struct
         |> Json.to_list
         |> List.map (fun r -> result_of_json r lines);
     }
+
+  let to_json { benchmark_name; results } =
+    let name =
+      match benchmark_name with
+      | None -> []
+      | Some name -> [ ("name", `String name) ]
+    in
+    `Assoc (name @ [ ("results", `List (List.map json_of_result results)) ])
 end
 
 module Latest = V2
 
 let version = 2
 let of_json json = Latest.of_json json
+let to_json t = Latest.to_json t
 
 let of_list jsons =
   List.fold_left (fun acc json -> Latest.merge acc [ of_json json ]) [] jsons

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -8,6 +8,7 @@ authors: ["Rizo Isrof <rizo@tarides.com" "Craig Ferguson <craig@tarides.com>" "G
 homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.0"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
@@ -27,7 +28,6 @@ depends: [
   "duration"
   "fpath"
   "logs"
-  "ocaml" {>= "4.08"}
   "postgresql"
   "rresult"
   "omigrate"


### PR DESCRIPTION
The monthly irmin benchmarks need to push their results via the http api (see https://github.com/ocurrent/current-bench#using-api-to-submit-benchmark-data ). This PR adds a small `Cobench` client library to ease its usage (task 4 of https://github.com/ocurrent/current-bench/issues/318).

It's not yet intended for public use, only internal usage for irmin at this point! We still need to complete the other (non http) parts and stabilize the interface :)