### PR TITLE
Pipeline: allow running benchmarks on a cron-like schedule

### DIFF
--- a/current-bench.opam
+++ b/current-bench.opam
@@ -35,6 +35,8 @@ depends: [
   "postgresql"
   "rresult"
   "omigrate"
+  "timere"
+  "timere-parse"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
 ]

--- a/pipeline/lib/clock.ml
+++ b/pipeline/lib/clock.ml
@@ -1,0 +1,58 @@
+open Lwt.Infix
+
+type t = string Current.t
+
+let next clock_descr =
+  let timeline = Timere.inter [ Timere.after (Timedesc.now ()); clock_descr ] in
+  match Timere.resolve timeline with
+  | Error msg -> failwith ("Clock.next: " ^ msg)
+  | Ok timeline -> (
+      match timeline () with
+      | Seq.Cons ((t_start, _), _) -> Timedesc.Timestamp.to_float_s t_start
+      | _ -> failwith "Clock.next: terminated")
+
+let now () = Timedesc.Timestamp.(to_float_s @@ now ())
+
+let rec sleep_until date =
+  let now = now () in
+  if now > date
+  then Lwt.return_unit
+  else Lwt_unix.sleep (date -. now +. 1.) >>= fun () -> sleep_until date
+
+let wait_next clock_descr = sleep_until (next clock_descr)
+let to_rfc3339 t = Option.get @@ Timedesc.to_rfc3339 t
+let now_rfc3339 () = to_rfc3339 @@ Timedesc.now ()
+
+let beginning_of_time =
+  Result.get_ok
+  @@ Timedesc.make ~year:2000 ~month:1 ~day:1 ~hour:0 ~minute:0 ~second:0 ()
+
+let monitor clock_descr =
+  let now = ref beginning_of_time in
+  let read () =
+    (* The first [read ()] is far in the past to avoid running the benchmarks
+     * when the pipeline is (re)started, but it will then be correct when this
+     * cron clock should actually trigger. *)
+    Lwt.return (Ok (to_rfc3339 !now))
+  in
+  let watch refresh =
+    let rec wait () =
+      wait_next clock_descr >>= fun () ->
+      now := Timedesc.now ();
+      refresh ();
+      wait ()
+    in
+
+    let thread = wait () in
+    Lwt.return (fun () ->
+        Lwt.cancel thread;
+        Lwt.return_unit)
+  in
+  let pp h = Fmt.string h "clock" in
+  Current.Monitor.create ~read ~watch ~pp
+
+let make clock_descr =
+  let open Current.Syntax in
+  Current.component "%s" clock_descr
+  |> let> () = Current.return () in
+     Current.Monitor.get (monitor (Timere_parse.timere_exn clock_descr))

--- a/pipeline/lib/dune
+++ b/pipeline/lib/dune
@@ -3,6 +3,7 @@
  (public_name pipeline)
  (libraries current current.fs current_docker current_git current_github
    current_ocluster capnp-rpc-unix current_web current_slack dockerfile
-   fmt.tty logs logs.fmt prometheus rresult uri postgresql yojson str)
+   fmt.tty logs logs.fmt prometheus rresult uri postgresql yojson str
+   timedesc.tzdb.full timedesc.tzlocal.unix timedesc timere-parse)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -34,6 +34,8 @@ module Benchmark : sig
 
   module Db : sig
     val insert : conninfo:Db_util.t -> t -> unit
-    val exists : conninfo:Db_util.t -> Repository.t -> bool
+
+    val exists :
+      conninfo:Db_util.t -> env:Custom_dockerfile.Env.t -> Repository.t -> bool
   end
 end

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -33,6 +33,8 @@ depends: [
   "rresult"
   "omigrate"
   "ocluster"
+  "timere"
+  "timere-parse"
 ]
 pin-depends: [
   [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]

--- a/pipeline/tests/dune
+++ b/pipeline/tests/dune
@@ -3,7 +3,7 @@
  (libraries alcotest alcotest-lwt current current.fs current_docker
    current_git current_github current_ocluster capnp-rpc-unix current_web
    current_slack dockerfile fmt.tty logs logs.fmt prometheus rresult uri
-   yojson str)
+   timedesc.tzdb.full timedesc.tzlocal.unix timedesc timere-parse yojson str)
  (preprocess
   (pps ppx_deriving_yojson))
  (instrumentation


### PR DESCRIPTION
This PR adds an option to run benchmarks on a different schedule than "as soon as a PR changes" https://github.com/ocurrent/current-bench/issues/312 . In the `environment/production.conf`, the optional `"schedule"` field specifies a time-based cron-like schedule:

```json
{
  "repositories": [
    {
      "name": "local/local",
      "worker": "autumn",
      "image": "ocaml/opam:debian-11-ocaml-4.14",
      "schedule": "04:00:00"
    },
```

Here the schedule would be everyday at 4 o'clock in the morning. The parsing / time-computations are done by [timere](https://github.com/daypack-dev/timere), but the parsing isn't documented (?) so here are some examples:
- `"00:00:00"` for everyday at midnight
- `"00:00:00 or 12:00:00"` for twice a day
- `"sunday and 12:00:00"` for every sunday at 12 o'clock
- `"1st and 23:00:00"` for every 1st of each month at 23 o'clock

The code is a bit more complicated than expected. By default, OCurrent provides primitives for caching a result for a duration of time ("this benchmark is valid for 1 day"), but this makes the initial timings dependent on when we start the pipeline. I wanted something a bit more human-friendly where we know precisely when the benchmarks will run.

@shakthimaan > A limitation of our database is that a benchmark run is associated with a unique git commit: If the repository is not updated in between two time schedules, then the benchmark will not be re-run (since the pipeline considers that no change happened). This will be an issue for repositories that have external sources of changes other than their git history (the irmin reports, probably sandmark nightly?) I'll open a new issue for this, as currently the time-scheduling is only useful for running `Slow` benchmarks less frequently.