### PR TITLE
Docker build arguments

### DIFF
--- a/current-bench.opam
+++ b/current-bench.opam
@@ -35,6 +35,8 @@ depends: [
   "postgresql"
   "rresult"
   "omigrate"
+  "timere"
+  "timere-parse"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
 ]

--- a/pipeline/lib/clock.ml
+++ b/pipeline/lib/clock.ml
@@ -1,0 +1,58 @@
+open Lwt.Infix
+
+type t = string Current.t
+
+let next clock_descr =
+  let timeline = Timere.inter [ Timere.after (Timedesc.now ()); clock_descr ] in
+  match Timere.resolve timeline with
+  | Error msg -> failwith ("Clock.next: " ^ msg)
+  | Ok timeline -> (
+      match timeline () with
+      | Seq.Cons ((t_start, _), _) -> Timedesc.Timestamp.to_float_s t_start
+      | _ -> failwith "Clock.next: terminated")
+
+let now () = Timedesc.Timestamp.(to_float_s @@ now ())
+
+let rec sleep_until date =
+  let now = now () in
+  if now > date
+  then Lwt.return_unit
+  else Lwt_unix.sleep (date -. now +. 1.) >>= fun () -> sleep_until date
+
+let wait_next clock_descr = sleep_until (next clock_descr)
+let to_rfc3339 t = Option.get @@ Timedesc.to_rfc3339 t
+let now_rfc3339 () = to_rfc3339 @@ Timedesc.now ()
+
+let beginning_of_time =
+  Result.get_ok
+  @@ Timedesc.make ~year:2000 ~month:1 ~day:1 ~hour:0 ~minute:0 ~second:0 ()
+
+let monitor clock_descr =
+  let now = ref beginning_of_time in
+  let read () =
+    (* The first [read ()] is far in the past to avoid running the benchmarks
+     * when the pipeline is (re)started, but it will then be correct when this
+     * cron clock should actually trigger. *)
+    Lwt.return (Ok (to_rfc3339 !now))
+  in
+  let watch refresh =
+    let rec wait () =
+      wait_next clock_descr >>= fun () ->
+      now := Timedesc.now ();
+      refresh ();
+      wait ()
+    in
+
+    let thread = wait () in
+    Lwt.return (fun () ->
+        Lwt.cancel thread;
+        Lwt.return_unit)
+  in
+  let pp h = Fmt.string h "clock" in
+  Current.Monitor.create ~read ~watch ~pp
+
+let make clock_descr =
+  let open Current.Syntax in
+  Current.component "%s" clock_descr
+  |> let> () = Current.return () in
+     Current.Monitor.get (monitor (Timere_parse.timere_exn clock_descr))

--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -10,6 +10,7 @@ type repo = {
   worker : string; [@default default_worker]
   image : string; [@default default_docker]
   schedule : string option; [@default None]
+  build_args : string list; [@default []]
 }
 [@@deriving yojson]
 
@@ -93,6 +94,7 @@ let find t name =
           worker = default_worker;
           image = default_docker;
           schedule = None;
+          build_args = [];
         };
       ]
   | configs -> configs

--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -7,6 +7,7 @@ module Env = struct
     image : string;
     dockerfile : [ `File of Fpath.t | `Contents of Dockerfile.t Current.t ];
     clock : string;
+    build_args : string list;
   }
 
   let compare a b =
@@ -115,5 +116,11 @@ let dockerfiles ~config ~repository =
           in
           (image, docker)
       in
-      { Env.worker = conf.Config.worker; image; dockerfile; clock })
+      {
+        Env.worker = conf.Config.worker;
+        image;
+        dockerfile;
+        clock;
+        build_args = conf.Config.build_args;
+      })
     envs

--- a/pipeline/lib/dune
+++ b/pipeline/lib/dune
@@ -3,6 +3,7 @@
  (public_name pipeline)
  (libraries current current.fs current_docker current_git current_github
    current_ocluster capnp-rpc-unix current_web current_slack dockerfile
-   fmt.tty logs logs.fmt prometheus rresult uri postgresql yojson str)
+   fmt.tty logs logs.fmt prometheus rresult uri postgresql yojson str
+   timedesc.tzdb.full timedesc.tzlocal.unix timedesc timere-parse)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -34,6 +34,8 @@ module Benchmark : sig
 
   module Db : sig
     val insert : conninfo:Db_util.t -> t -> unit
-    val exists : conninfo:Db_util.t -> Repository.t -> bool
+
+    val exists :
+      conninfo:Db_util.t -> env:Custom_dockerfile.Env.t -> Repository.t -> bool
   end
 end

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -91,7 +91,12 @@ let pipeline ~config ~ocluster ~conninfo ~repository env =
   let serial_id =
     Storage.setup_metadata ~repository ~conninfo ~worker ~docker_image
   in
-  let docker_options = Cluster_api.Docker.Spec.defaults in
+  let docker_options =
+    {
+      Cluster_api.Docker.Spec.defaults with
+      build_args = env.Custom_dockerfile.Env.build_args;
+    }
+  in
   let dockerfile =
     match env.Env.dockerfile with
     | `Contents d -> `Contents (Current.map Dockerfile.string_of_t d)

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -33,6 +33,8 @@ depends: [
   "rresult"
   "omigrate"
   "ocluster"
+  "timere"
+  "timere-parse"
 ]
 pin-depends: [
   [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#739c80bfda5290e6b0b854372db60789ac83ec97"]

--- a/pipeline/tests/dune
+++ b/pipeline/tests/dune
@@ -3,7 +3,7 @@
  (libraries alcotest alcotest-lwt current current.fs current_docker
    current_git current_github current_ocluster capnp-rpc-unix current_web
    current_slack dockerfile fmt.tty logs logs.fmt prometheus rresult uri
-   yojson str)
+   timedesc.tzdb.full timedesc.tzlocal.unix timedesc timere-parse yojson str)
  (preprocess
   (pps ppx_deriving_yojson))
  (instrumentation


### PR DESCRIPTION
(This builds on top of https://github.com/ocurrent/current-bench/pull/335 to avoid a merge conflict later)

As noted in https://github.com/ocurrent/current-bench/issues/333 we need to customize the docker build to allow different settings in sandmark nightly. In the `environment/*.conf`, one can add the optional `"build_args"` setting:

```json
{
  "repositories": [
    {
      "name": "local/local",
      "worker": "autumn",
      "build_args": ["FOO=42"]
    },
```

The arguments will be available to the custom `bench.Dockerfile`. For example, one can simply re-export the build argument as an environment variable:

```Dockerfile
FROM ocaml/opam
COPY . .
ARG FOO
ENV FOO $FOO
```

which will make it available at runtime to the `make bench` command:

```Makefile
bench:
	echo "FOO is ${FOO}"
```

This should play well with the cron-like scheduling to support the long awaited feature of `Quick` and `Slow` benchmarks https://github.com/ocurrent/current-bench/issues/23 : The default `make bench` would run the quick benchmarks on every modifications (as usual), and a separate worker would run the slow benchmarks on a daily/weekly schedule (by setting an appropriate build argument so that the benchmarking command becomes `MODE=slow make bench`).