### PR TITLE
Fix missing value frontend crash

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -107,9 +107,11 @@ module Benchmark = {
 
   @react.component
   let make = React.memo((~repoId, ~pullNumber, ~data: GetBenchmarks.t, ~lastCommit) => {
-    let benchmarkDataByTestName = React.useMemo2(() => {
-      data.benchmarks->makeBenchmarkData->AdjustMetricUnit.adjust->AppHelpers.fillMissingValues
-    }, (data.benchmarks, makeBenchmarkData))
+    let benchmarkDataByTestName = React.useMemo2(
+      () =>
+        data.benchmarks->makeBenchmarkData->AdjustMetricUnit.adjust->AppHelpers.fillMissingValues,
+      (data.benchmarks, makeBenchmarkData),
+    )
 
     let comparisonBenchmarkDataByTestName = React.useMemo2(
       () =>

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -116,7 +116,8 @@ module Benchmark = {
         data.comparisonBenchmarks
         ->Belt.Array.reverse
         ->makeBenchmarkData
-        ->AppHelpers.fillMissingValues,
+        ->AppHelpers.fillMissingValues
+        ->AppHelpers.addMissingComparisonMetrics(benchmarkDataByTestName),
       (data.comparisonBenchmarks, makeBenchmarkData),
     )
 

--- a/frontend/src/AppHelpers.res
+++ b/frontend/src/AppHelpers.res
@@ -54,13 +54,14 @@ let addMissingCommits = ((metricTimeseries, metricMetadata) as data, allCommits)
       // overwritten.  Other metadata like units, trend, description are the
       // same as metadata in the last commit.
       let templateMetadata = BeltHelpers.Array.lastExn(metricMetadata)
-      let filledMetadata =
-        allCommits->Belt.Array.map(((commit, runAt, run_job_id)) =>
-          Js.Obj.assign(
-            templateMetadata,
-            {"commit": commit, "runAt": runAt, "run_job_id": run_job_id, "lines": []},
-          )
-        )
+      let filledMetadata = allCommits->Belt.Array.map(((commit, runAt, run_job_id)) => {
+        Js.Obj.assign(Js.Obj.empty(), templateMetadata)->Js.Obj.assign({
+          "commit": commit,
+          "runAt": runAt,
+          "run_job_id": run_job_id,
+          "lines": [],
+        })
+      })
       (filledTimeseries, filledMetadata)
     }
   }

--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -240,10 +240,7 @@ let make = (
       // FIXME: Validate that units are same on all the overlays? (ideally, in the current_bench_json.ml)
       let seriesArrays =
         names->Belt.Array.map(x => getSeriesArrays(dataByMetricName, comparison, x))
-      let (_, metadata, comparisonTimeseries, _f) = seriesArrays[0]
-      let mergedMetadata = isOverlayed
-        ? seriesArrays->Belt.Array.map(((_, md, _, _)) => md)->Belt.Array.getExn(0)
-        : metadata
+      let mergedMetadata = seriesArrays->Belt.Array.map(((_, md, _, _)) => md)->Belt.Array.getExn(0)
       let tsArrays = seriesArrays->Belt.Array.map(((ts, _, _, _)) => ts)
       let xTicks = mergedMetadata->Belt.Array.reduceWithIndex(Belt.Map.Int.empty, (
         acc,
@@ -266,7 +263,12 @@ let make = (
       let lines = (mergedMetadata->BeltHelpers.Array.lastExn)["lines"]
       let run_job_id = (mergedMetadata->BeltHelpers.Array.lastExn)["run_job_id"]
       let labels = suffixes
-      let firstPullX = Belt.Array.length(comparisonTimeseries)
+      let firstPullX =
+        seriesArrays
+        ->Belt.Array.map(((_, _, ts, _)) => ts)
+        ->Belt.Array.get(0)
+        ->Belt.Option.getWithDefault([])
+        ->Belt.Array.length
       let annotations =
         firstPullX > 0
           ? labels->Belt.Array.map(x => makeAnnotation(firstPullX, x, repoId, pullNumber))


### PR DESCRIPTION
- Fixes front-end crash when an (overlaid) metric is added on a branch, and there are no corresponding comparison metrics
- Also, fixes a bug with using `Js.Obj.assign` incorrectly. 