### PR TITLE
frontend: Fix broken line numbers when filling in missing commits

### DIFF
--- a/frontend/src/AppHelpers.res
+++ b/frontend/src/AppHelpers.res
@@ -56,12 +56,16 @@ let addMissingCommits = ((metricTimeseries, metricMetadata) as data, allCommits)
       // same as metadata in the last commit.
       let templateMetadata = BeltHelpers.Array.lastExn(metricMetadata)
       let filledMetadata = allCommits->Belt.Array.map(((commit, runAt, run_job_id)) => {
-        Js.Obj.assign(Js.Obj.empty(), templateMetadata)->Js.Obj.assign({
-          "commit": commit,
-          "runAt": runAt,
-          "run_job_id": run_job_id,
-          "lines": [],
-        })
+        switch metricMetadata->Belt.Array.getBy(md => md["commit"] == commit) {
+        | Some(metadata) => metadata
+        | _ =>
+          Js.Obj.assign(Js.Obj.empty(), templateMetadata)->Js.Obj.assign({
+            "commit": commit,
+            "runAt": runAt,
+            "run_job_id": run_job_id,
+            "lines": [],
+          })
+        }
       })
       (filledTimeseries, filledMetadata)
     }


### PR DESCRIPTION
This code to fill up missing commit values had so many bug fix commits. At some point, I think it would be good to write some tests for this, and also see if we can simplify the whole thing. :see_no_evil: 