### PR TITLE
Frontend: hide table comparison rows NA/NA

### DIFF
--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -84,16 +84,10 @@ let renderMetricOverviewRow = (
     ~comparison=(comparisonTimeseries, _comparisonMetadata),
     (timeseries, metadata),
   )
-  switch row.last_value {
-  | None => React.null
-  | Some(last_value) => {
-      let (vsMasterAbs, vsMasterRel) = switch (row.comparison_value, row.delta) {
-      | (Some(y), Some(delta)) => (
-          Js.Float.toPrecisionWithPrecision(~digits=6)(y),
-          delta->deltaToString,
-        )
-      | _ => ("NA", "NA")
-      }
+  switch (row.last_value, row.comparison_value, row.delta) {
+  | (Some(last_value), Some(vsMasterAbs), Some(vsMasterRel)) => {
+      let vsMasterAbs = Js.Float.toPrecisionWithPrecision(~digits=6)(vsMasterAbs)
+      let vsMasterRel = vsMasterRel->deltaToString
       let color = switch isFavourableDelta(row) {
       | Some(true) => Sx.green300
       | Some(false) => Sx.red300
@@ -110,6 +104,7 @@ let renderMetricOverviewRow = (
         <Table.Col sx=[Sx.text.right, Sx.text.color(color)]> {Rx.text(vsMasterRel)} </Table.Col>
       </Table.Row>
     }
+  | _ => React.null
   }
 }
 


### PR DESCRIPTION
The `main` branch displays a large table of "comparisons values" for the latest commit and the fork: this makes sense for PRs, but otherwise there isn't any fork to compare to (so it only shows the latest value already visible in each graph summary, and `NA / NA` for the missing fork value).