### PR TITLE
Correctly handle carriage returns when counting line numbers

### DIFF
--- a/pipeline/tests/json_stream_test.ml
+++ b/pipeline/tests/json_stream_test.ml
@@ -17,9 +17,10 @@ let parse_one =
   let str =
     String.concat "\n"
       [
-        "debug line";
+        "debug line\r\r";
         {|{"json": true}|};
         "more stuff";
+        "(Reading database ...\r(Reading database ... 5%";
         "more stuff";
         {|{"ok": ["yes"]}|};
         "...";
@@ -28,7 +29,7 @@ let parse_one =
   let state = Json_stream.make_json_parser () in
   let parsed, _state = Json_stream.json_steps ([], state) str in
   let expect =
-    [ ({|{"ok": ["yes"]}|}, (5, 5)); ({|{"json": true}|}, (2, 2)) ]
+    [ ({|{"ok": ["yes"]}|}, (8, 8)); ({|{"json": true}|}, (3, 3)) ]
   in
   Alcotest.(check (list parsed_location)) "jsons" expect parsed
 


### PR DESCRIPTION
Previously, the line number counting code didn't increment line numbers when
encoutering carriage returns.  This is in-line with the line numbers displayed
by Unix tools like `cat -n`, for instance.  But browsers treat `\r` characters
differently -- `\r`, `\r\n` and `\n`, all display a newline in browsers.