### PR TITLE
frontend: Use same color for a sub-metric across different graphs

### DIFF
--- a/frontend/src/BenchmarkTest.res
+++ b/frontend/src/BenchmarkTest.res
@@ -177,6 +177,7 @@ let make = (
   ~comparison=Belt.Map.String.empty,
   ~dataByMetricName: Belt.Map.String.t<(array<LineGraph.DataRow.t>, 'a)>,
   ~lastCommit,
+  ~labelColorMapping: Belt.Map.String.t<string>,
 ) => {
   let metric_table = {
     <Table sx=[Sx.mb.xl2]>
@@ -310,6 +311,7 @@ let make = (
           lines
           run_job_id
           failedMetric
+          labelColorMapping
         />
       </div>
     }


### PR DESCRIPTION
To make it easier to parse and understand graphs for metrics like ocaml/ocaml
which show the compiler parsing, generation, typing times across different
projects, we use the same color for each of these sub-metrics.

Closes #344

![image](https://user-images.githubusercontent.com/315678/161911841-98a3d088-415a-4a6e-ab98-8d3936d36992.png)
