### PR TITLE
Ensure comparison benchmark size metrics use correct units

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -113,14 +113,14 @@ module Benchmark = {
       (data.benchmarks, makeBenchmarkData),
     )
 
-    let comparisonBenchmarkDataByTestName = React.useMemo2(
+    let comparisonBenchmarkDataByTestName = React.useMemo3(
       () =>
         data.comparisonBenchmarks
         ->Belt.Array.reverse
         ->makeBenchmarkData
         ->AppHelpers.fillMissingValues
         ->AppHelpers.addMissingComparisonMetrics(benchmarkDataByTestName),
-      (data.comparisonBenchmarks, makeBenchmarkData),
+      (data.benchmarks, data.comparisonBenchmarks, makeBenchmarkData),
     )
 
     let graphsData = React.useMemo1(() => {

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -118,6 +118,7 @@ module Benchmark = {
         data.comparisonBenchmarks
         ->Belt.Array.reverse
         ->makeBenchmarkData
+        ->AdjustMetricUnit.adjustComparisonData(benchmarkDataByTestName)
         ->AppHelpers.fillMissingValues
         ->AppHelpers.addMissingComparisonMetrics(benchmarkDataByTestName),
       (data.benchmarks, data.comparisonBenchmarks, makeBenchmarkData),


### PR DESCRIPTION
Previously, the size units were not adjusted on the comparision benchmark data.
This commit ensures that the same units are used for each metric in the
comparision benchmark data as the unit for those metrics in the benchmark data.

*Before*
![image](https://user-images.githubusercontent.com/315678/162115051-e75e2eae-d774-4be5-a7d9-864aa92c54cd.png)

*After*
![image](https://user-images.githubusercontent.com/315678/162115105-81958216-82c0-4187-ad5a-77c7b9116f36.png)

Closes #322 