### PR TITLE
Opam install test dependencies

### DIFF
--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -78,7 +78,7 @@ let install_opam_dependencies ~files =
     copy ~src:[ "--chown=opam:opam ./*.opam" ] ~dst:"./" ()
     @@ run "opam exec -- opam pin -y -n --with-version=dev ."
     @@ run "opam exec -- opam install -y --depext-only ."
-    @@ run "opam exec -- opam install -y --deps-only ."
+    @@ run "opam exec -- opam install -y --deps-only --with-test ."
 
 let dockerfile ~base ~files =
   let open Dockerfile in


### PR DESCRIPTION
We've had a bit of a back-and-forth on this issue before... In general running the benchmarks requires more dependencies than the "default basic installation", so it's a better default if we also install the `{with-test}` libraries from the `opam` file (and not force the user to maintain a custom `*-bench.opam`)