### PR TITLE
Record commit messages and display them on hover on commit IDs

### DIFF
--- a/current-bench.opam
+++ b/current-bench.opam
@@ -29,6 +29,7 @@ depends: [
   "ocluster-worker"  {= "dev"}
   "obuilder"         {= "dev"}
   "obuilder-spec"    {= "dev"}
+  "dockerfile"
   "duration"
   "fpath"
   "logs"
@@ -43,13 +44,13 @@ depends: [
 
 pin-depends: [
   [ "reason.dev" "git+https://github.com/reasonml/reason.git#ccc34729994b4a80d4f6274cc0165cd9113444d6"]
-  [ "current_docker.dev" "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_github.dev" "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_slack.dev"  "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_web.dev"    "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
+  [ "current_docker.dev" "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_github.dev" "git+https://github.com/punchagan/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_slack.dev"  "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_web.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current_ocluster.dev" "git+https://github.com/art-w/ocluster.git#f5884b0e8454c29c156cda939416436565206e24" ]
   [ "ocluster-api.dev"     "git+https://github.com/art-w/ocluster.git#f5884b0e8454c29c156cda939416436565206e24" ]
   [ "ocluster-worker.dev"  "git+https://github.com/art-w/ocluster.git#f5884b0e8454c29c156cda939416436565206e24" ]

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -45,7 +45,7 @@ depends: [
 pin-depends: [
   [ "reason.dev" "git+https://github.com/reasonml/reason.git#ccc34729994b4a80d4f6274cc0165cd9113444d6"]
   [ "current_docker.dev" "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
-  [ "current_github.dev" "git+https://github.com/punchagan/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_github.dev" "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]

--- a/frontend/graphql_schema.json
+++ b/frontend/graphql_schema.json
@@ -2603,6 +2603,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "commit_message",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "docker_image",
             "type": {
               "kind": "NON_NULL",
@@ -3299,6 +3311,16 @@
             "description": null
           },
           {
+            "name": "commit_message",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "docker_image",
             "defaultValue": null,
             "type": {
@@ -3524,6 +3546,16 @@
             "description": null
           },
           {
+            "name": "commit_message",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "docker_image",
             "defaultValue": null,
             "type": {
@@ -3701,6 +3733,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "commit_message",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "docker_image",
             "type": {
               "kind": "SCALAR",
@@ -3831,6 +3875,16 @@
           },
           {
             "name": "commit",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "commit_message",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -3987,6 +4041,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "commit_message",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "docker_image",
             "type": {
               "kind": "SCALAR",
@@ -4117,6 +4183,16 @@
           },
           {
             "name": "commit",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "commit_message",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -4410,6 +4486,16 @@
             "description": null
           },
           {
+            "name": "commit_message",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "docker_image",
             "defaultValue": null,
             "type": {
@@ -4597,6 +4683,12 @@
           {
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "commit_message",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "docker_image",
             "description": "column name"
           },
@@ -4704,6 +4796,16 @@
           },
           {
             "name": "commit",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "commit_message",
             "defaultValue": null,
             "type": {
               "kind": "SCALAR",
@@ -5134,6 +5236,12 @@
             "isDeprecated": false,
             "deprecationReason": null,
             "name": "commit",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "commit_message",
             "description": "column name"
           },
           {

--- a/frontend/src/CommitInfo.res
+++ b/frontend/src/CommitInfo.res
@@ -22,6 +22,7 @@ query ($repoId: String!,
     pull_number
     branch
     commit
+    commit_message
     build_job_id
     run_job_id
     failed
@@ -63,9 +64,9 @@ let containerSx = [
 
 let linkStyle = [Sx.text.bold, Sx.text.lg, Sx.p.zero]
 
-let renderExternalLink = (~style=linkStyle, ~href, text) => {
+let renderExternalLink = (~style=linkStyle, ~href, ~title="", text) => {
   let sx = Array.concat(list{Link.sx_base, style})
-  <a target="_blank" className={Sx.make(sx)} href> {Rx.text(text)} </a>
+  <a target="_blank" title className={Sx.make(sx)} href> {Rx.text(text)} </a>
 }
 
 let renderJobIdLink = (jobId, ~text) => {
@@ -74,10 +75,11 @@ let renderJobIdLink = (jobId, ~text) => {
   renderExternalLink(~style, ~href, text)
 }
 
-let renderCommitLink = (~style=linkStyle, repoId, commit) =>
+let renderCommitLink = (~style=linkStyle, repoId, commit, commit_message) =>
   renderExternalLink(
     ~style,
     ~href=AppHelpers.commitUrl(~repoId, commit),
+    ~title=commit_message,
     DataHelpers.trimCommit(commit),
   )
 
@@ -177,7 +179,11 @@ let make = (~repoId, ~pullNumber=?, ~benchmarks: GetBenchmarks.t, ~worker, ~setL
       <Row sx=containerSx spacing=#between alignY=#top>
         <Column spacing=Sx.sm>
           <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.gray700)]> "Last Commit" </Text>
-          {renderCommitLink(repoId, lastCommitInfo.commit)}
+          {renderCommitLink(
+            repoId,
+            lastCommitInfo.commit,
+            Belt.Option.getWithDefault(lastCommitInfo.commit_message, ""),
+          )}
         </Column>
         <Column spacing=Sx.sm>
           <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.gray700)]>
@@ -227,7 +233,7 @@ let make = (~repoId, ~pullNumber=?, ~benchmarks: GetBenchmarks.t, ~worker, ~setL
           <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.yellow600)]>
             "Metrics for an older commit "
           </Text>
-          {renderCommitLink(~style=[Sx.text.bold, Sx.text.xs, Sx.p.zero], repoId, benchmark)}
+          {renderCommitLink(~style=[Sx.text.bold, Sx.text.xs, Sx.p.zero], repoId, benchmark, "")}
           <Text sx=[Sx.text.bold, Sx.text.xs, Sx.text.color(Sx.yellow600)]>
             " are shown below"
           </Text>

--- a/hasura-server/metadata/tables.yaml
+++ b/hasura-server/metadata/tables.yaml
@@ -32,6 +32,7 @@
       - run_at
       - repo_id
       - commit
+      - commit_message
       - branch
       - pull_number
       - is_open_pr

--- a/pipeline/db/migrations/20220422101917_add_commit_message.down.sql
+++ b/pipeline/db/migrations/20220422101917_add_commit_message.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE benchmark_metadata DROP COLUMN;

--- a/pipeline/db/migrations/20220422101917_add_commit_message.up.sql
+++ b/pipeline/db/migrations/20220422101917_add_commit_message.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE benchmark_metadata ADD COLUMN commit_message TEXT;

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -179,7 +179,10 @@ let github_repositories repo =
         try Github.Api.Ref_map.find key title_map with Not_found -> None
       in
       let commit = Github.Api.Commit.id head in
-      let repository = repository ~commit ~github_head:head ?title in
+      let message = Github.Api.Commit.message head in
+      let repository =
+        repository ~commit ~github_head:head ~commit_message:message ?title
+      in
       (* If commit is more than two weeks old, then skip it.*)
       if Github.Api.Commit.committed_date head > stale_timestamp
       then

--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -3,6 +3,7 @@ type t = {
   name : string;
   src : Current_git.Commit.t Current.t;
   commit : Current_git.Commit_id.t;
+  commit_message : string option;
   pull_number : int option;
   branch : string option;
   github_head : Current_github.Api.Commit.t option;
@@ -14,11 +15,13 @@ let default_src ?src commit =
   | None -> Current_git.fetch (Current.return commit)
   | Some src -> src
 
-let v ~owner ~name ?src ~commit ?pull_number ?branch ?github_head ?title () =
+let v ~owner ~name ?src ~commit ?commit_message ?pull_number ?branch
+    ?github_head ?title () =
   {
     owner;
     name;
     commit;
+    commit_message;
     pull_number;
     branch;
     github_head;
@@ -30,6 +33,7 @@ let owner t = t.owner
 let name t = t.name
 let src t = t.src
 let commit t = t.commit
+let commit_message t = t.commit_message
 let commit_hash t = Current_git.Commit_id.hash t.commit
 let pull_number t = t.pull_number
 let title t = t.title

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -26,6 +26,7 @@ depends: [
   "current_incr" {>= "0.5"}
   "current_ansi"
   "current_ocluster"
+  "dockerfile"
   "duration"
   "fpath"
   "logs"
@@ -37,13 +38,13 @@ depends: [
   "timere-parse"
 ]
 pin-depends: [
-  [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_docker.dev" "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_github.dev" "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_slack.dev"  "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
-  [ "current_web.dev"    "git+https://github.com/ocurrent/ocurrent.git#8b6d09b1b09e9967c0b55989ac3fe5d51f625648"]
+  [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_docker.dev" "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_github.dev" "git+https://github.com/punchagan/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_slack.dev"  "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_web.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -40,7 +40,7 @@ depends: [
 pin-depends: [
   [ "current.dev"        "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current_docker.dev" "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
-  [ "current_github.dev" "git+https://github.com/punchagan/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
+  [ "current_github.dev" "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current_git.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current_rpc.dev"    "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]
   [ "current_slack.dev"  "git+https://github.com/ocurrent/ocurrent.git#f43ba4485dcd599c15139d8b923328fd0a777aa9"]

--- a/pipeline/tests/api_test.ml
+++ b/pipeline/tests/api_test.ml
@@ -90,13 +90,13 @@ let empty_benchmarks =
       Postgresql.Expect
         (fun ?expect query ->
           let expected =
-            "INSERT INTO benchmark_metadata (run_at, repo_id, commit, branch, \
-             pull_number, pr_title, worker, docker_image) VALUES \
-             (to_timestamp(XXX), 'myowner/myrepo', 'abcd12345', 'main', NULL, \
-             NULL, 'remote', 'external') ON CONFLICT(repo_id, commit, worker, \
-             docker_image) DO UPDATE SET build_job_id = NULL, run_job_id = \
-             NULL, failed = false, cancelled = false, success = false, reason \
-             = '' RETURNING id;"
+            "INSERT INTO benchmark_metadata (run_at, repo_id, commit, \
+             commit_message, branch, pull_number, pr_title, worker, \
+             docker_image) VALUES (to_timestamp(XXX), 'myowner/myrepo', \
+             'abcd12345', NULL, 'main', NULL, NULL, 'remote', 'external') ON \
+             CONFLICT(repo_id, commit, worker, docker_image) DO UPDATE SET \
+             build_job_id = NULL, run_job_id = NULL, failed = false, cancelled \
+             = false, success = false, reason = '' RETURNING id;"
           in
           Alcotest.(check string) "setup metadata" expected query;
           assert (expect = None);


### PR DESCRIPTION
This commit depends on a modified version of [`ocurrent`](https://github.com/punchagan/ocurrent/tree/capture-commit-message) that fetches the commit messages from GitHub.  The PR temporarily points to that commit of `ocurrent`. I'm not sure if we should wait to merge this PR until we submit that change, or if there's a better way to go about this.  