### PR TITLE
Install *-bench.opam in priority

### DIFF
--- a/pipeline/lib/storage.ml
+++ b/pipeline/lib/storage.ml
@@ -123,6 +123,7 @@ let mark_closed_pull_requests ~open_pulls (db : Postgresql.connection) =
            Fmt.str {|(repo_id = '%s' AND pull_number = %d)|} repo_id pull_number)
          open_pulls
   in
+  let open_pr_query = if open_pr_query <> "" then open_pr_query else "FALSE" in
   let query =
     Fmt.str
       {|UPDATE benchmark_metadata


### PR DESCRIPTION
In order to run the irmin benchmarks on the raspberry pi 4, we need to skip the installation of `libirmin.opam` (which disables arm64)... so we must only install the `irmin-bench.opam` and its dependencies, not everything.