### PR TITLE
pipeline: Don't filter out local repository as stale repo

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -200,6 +200,7 @@ let filter_stale_repositories repos =
       | Some head when Github.Api.Commit.committed_date head > stale_timestamp
         ->
           Some repo
+      | None when Repository.info repo = "local/local" -> Some repo
       | _ -> None)
     repos
 


### PR DESCRIPTION
This commit fixes the bug introduced in
2ff8bb142205b15fcf8e43262515bd70cca5e303 which incorrectly filters out
"local/local" repository when filtering stale repositories.