### PR TITLE
Allow running benchmarks from a different repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ coverage: ./local-repos/test/.git
 
 .PHONY: local-make-bench
 local-make-bench: ./local-repos/test/.git
-	cd local-repos/test/; git add .; git commit --amend -m "New commit: $$(date)"; cd ..
+	cd local-repos/test/; git add .; git commit --amend -m "New commit: $$(date)"; echo "Created new commit: $$(git rev-parse HEAD)"; cd ..
 
 .PHONY: migration
 migration:

--- a/cobench/cobench.ml
+++ b/cobench/cobench.ml
@@ -19,7 +19,9 @@ let of_metrics ~name ms = { L.test_name = name; metrics = ms }
 
 type t = L.t
 
-let of_results results = { L.benchmark_name = None; results }
+let of_results results =
+  { L.benchmark_name = None; results; target_version = None }
+
 let to_json = L.to_json
 let of_json = L.of_json
 

--- a/cobench/cobench.ml
+++ b/cobench/cobench.ml
@@ -20,7 +20,12 @@ let of_metrics ~name ms = { L.test_name = name; metrics = ms }
 type t = L.t
 
 let of_results results =
-  { L.benchmark_name = None; results; target_version = None }
+  {
+    L.benchmark_name = None;
+    results;
+    target_version = None;
+    target_name = None;
+  }
 
 let to_json = L.to_json
 let of_json = L.of_json

--- a/frontend/graphql_schema.json
+++ b/frontend/graphql_schema.json
@@ -2767,6 +2767,38 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "target_name",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "worker",
             "type": {
               "kind": "NON_NULL",
@@ -3431,6 +3463,26 @@
             "description": null
           },
           {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "worker",
             "defaultValue": null,
             "type": {
@@ -3666,6 +3718,26 @@
             "description": null
           },
           {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "worker",
             "defaultValue": null,
             "type": {
@@ -3841,6 +3913,30 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "target_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "worker",
             "type": {
               "kind": "SCALAR",
@@ -3965,6 +4061,26 @@
           },
           {
             "name": "run_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -4149,6 +4265,30 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "target_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "worker",
             "type": {
               "kind": "SCALAR",
@@ -4273,6 +4413,26 @@
           },
           {
             "name": "run_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -4606,6 +4766,26 @@
             "description": null
           },
           {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "worker",
             "defaultValue": null,
             "type": {
@@ -4750,6 +4930,18 @@
             "isDeprecated": false,
             "deprecationReason": null,
             "name": "success",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_name",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
             "description": "column name"
           },
           {
@@ -4920,6 +5112,26 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "description": null
@@ -5313,6 +5525,18 @@
           {
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "target_name",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "worker",
             "description": "column name"
           }
@@ -5687,6 +5911,38 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_name",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "description": null
           },
@@ -6399,6 +6655,26 @@
             "description": null
           },
           {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "test_index",
             "defaultValue": null,
             "type": {
@@ -6685,6 +6961,26 @@
             "description": null
           },
           {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "test_index",
             "defaultValue": null,
             "type": {
@@ -6854,6 +7150,30 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "target_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
             "type": {
               "kind": "SCALAR",
@@ -6984,6 +7304,26 @@
           },
           {
             "name": "run_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -7162,6 +7502,30 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "target_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
             "type": {
               "kind": "SCALAR",
@@ -7292,6 +7656,26 @@
           },
           {
             "name": "run_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -7605,6 +7989,26 @@
             "description": null
           },
           {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "test_index",
             "defaultValue": null,
             "type": {
@@ -7750,6 +8154,18 @@
           {
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "target_name",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "test_index",
             "description": "column name"
           },
@@ -7879,6 +8295,26 @@
           },
           {
             "name": "run_job_id",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_name",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "target_version",
             "defaultValue": null,
             "type": {
               "kind": "SCALAR",
@@ -8359,6 +8795,18 @@
             "isDeprecated": false,
             "deprecationReason": null,
             "name": "run_job_id",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_name",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "target_version",
             "description": "column name"
           },
           {

--- a/frontend/src/BenchmarkData.res
+++ b/frontend/src/BenchmarkData.res
@@ -15,6 +15,8 @@ let add = (
   ~metricName,
   ~runAt: Js.Date.t,
   ~commit,
+  ~target_version,
+  ~target_name,
   ~value: LineGraph.DataRow.t,
   ~units: LineGraph.DataRow.units,
   ~description,
@@ -32,6 +34,8 @@ let add = (
     metadata,
     {
       commit: commit,
+      target_version: target_version,
+      target_name: target_name,
       runAt: runAt,
       units: units,
       description: description,

--- a/frontend/src/BenchmarkDataHelpers.res
+++ b/frontend/src/BenchmarkDataHelpers.res
@@ -116,6 +116,8 @@ let addMissingComparisonMetrics = (comparisonBenchmarkDataByTestName, benchmarkD
               run_job_id,
             )): LineGraph.DataRow.md => {
               commit: commit,
+              target_version: Some(""),
+              target_name: Some(""),
               runAt: runAt,
               run_job_id: run_job_id,
               lines: []->Belt.List.fromArray,

--- a/frontend/src/BenchmarkQueryHelpers.res
+++ b/frontend/src/BenchmarkQueryHelpers.res
@@ -3,6 +3,8 @@ fragment BenchmarkMetrics on benchmarks {
   version
   run_at
   commit
+  target_version
+  target_name
   test_name
   test_index
   metrics

--- a/frontend/src/LineGraph.res
+++ b/frontend/src/LineGraph.res
@@ -59,6 +59,8 @@ module DataRow = {
 
   type md = {
     commit: string,
+    target_version: option<string>,
+    target_name: option<string>,
     runAt: Js.Date.t,
     units: units,
     description: string,

--- a/hasura-server/metadata/tables.yaml
+++ b/hasura-server/metadata/tables.yaml
@@ -9,6 +9,8 @@
       - run_at
       - repo_id
       - commit
+      - target_version
+      - target_name
       - branch
       - pull_number
       - benchmark_name
@@ -33,6 +35,8 @@
       - repo_id
       - commit
       - commit_message
+      - target_version
+      - target_name
       - branch
       - pull_number
       - is_open_pr

--- a/local-repos/test/Makefile
+++ b/local-repos/test/Makefile
@@ -1,6 +1,9 @@
 define BENCH_DATA_B1_T1_A
 {
-  "config": null,
+  "config": {
+    "target_version": "bcffd84a9b0e38a3ca02a1ffd2de54541f3bcb9f",
+    "target_name": "ocaml/ocaml"
+  },
   "version": 2,
   "results": [
     {
@@ -32,7 +35,10 @@ endef
 
 define BENCH_DATA_B1_T1_B
 {
-  "config": null,
+  "config": {
+    "target_version": "bcffd84a9b0e38a3ca02a1ffd2de54541f3bcb9f",
+    "target_name": "ocaml/ocaml"
+  },
   "version": 2,
   "results": [
     {
@@ -59,7 +65,10 @@ endef
 
 define BENCH_DATA_B1_T2
 {
-  "config": null,
+  "config": {
+    "target_version": "bcffd84a9b0e38a3ca02a1ffd2de54541f3bcb9f",
+    "target_name": "ocaml/ocaml"
+  },
   "version": 1,
   "results": [
     {

--- a/pipeline/db/migrations/20220629121922_add_target_project_version_column_to_benchmarks.down.sql
+++ b/pipeline/db/migrations/20220629121922_add_target_project_version_column_to_benchmarks.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE benchmarks
+    DROP COLUMN target_version,
+    DROP COLUMN target_name;
+
+ALTER TABLE benchmark_metadata
+    DROP COLUMN target_version,
+    DROP COLUMN target_name;

--- a/pipeline/db/migrations/20220629121922_add_target_project_version_column_to_benchmarks.up.sql
+++ b/pipeline/db/migrations/20220629121922_add_target_project_version_column_to_benchmarks.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE benchmarks
+    ADD COLUMN target_version varchar(256) NOT NULL default '',
+    ADD COLUMN target_name varchar(256) NOT NULL default '';
+
+ALTER TABLE benchmark_metadata
+    ADD COLUMN target_version varchar(256) NOT NULL default '',
+    ADD COLUMN target_name varchar(256) NOT NULL default '';

--- a/pipeline/db/migrations/20220714092902_unique_run.down.sql
+++ b/pipeline/db/migrations/20220714092902_unique_run.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE benchmark_metadata
+DROP CONSTRAINT unique_run,
+ADD CONSTRAINT unique_run UNIQUE(repo_id, commit, worker, docker_image);

--- a/pipeline/db/migrations/20220714092902_unique_run.up.sql
+++ b/pipeline/db/migrations/20220714092902_unique_run.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE benchmark_metadata
+DROP CONSTRAINT unique_run,
+ADD CONSTRAINT unique_run UNIQUE(repo_id, commit, target_version, worker, docker_image);

--- a/pipeline/lib/api.ml
+++ b/pipeline/lib/api.ml
@@ -101,6 +101,7 @@ let make_benchmark_from_request ~conninfo ~body ~token =
   authorize_token token repository;
   let serial_id =
     Storage.setup_metadata ~repository ~conninfo ~worker ~docker_image
+      ~target_version:(Some "") ~target_name:(Some "")
   in
   ignore
     (benchmarks

--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -14,6 +14,8 @@ type repo = {
   build_args : string list; [@default []]
   notify_github : bool; [@default false]
   if_label : string option; [@default None]
+  target_version : string option; [@default None]
+  target_name : string option; [@default None]
 }
 [@@deriving yojson]
 
@@ -97,6 +99,8 @@ let default name =
     schedule = None;
     build_args = [];
     notify_github = false;
+    target_version = None;
+    target_name = None;
     if_label = None;
   }
 

--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -135,5 +135,17 @@ let dockerfiles ~config ~repository =
             in
             (image, docker)
       in
-      { Env.worker = conf.worker; image; dockerfile; clock; config = conf })
+      let build_args =
+        match conf.Config.target_version with
+        | Some version ->
+            ("TARGET_VERSION=" ^ version) :: conf.Config.build_args
+        | _ -> conf.Config.build_args
+      in
+      let build_args =
+        match conf.Config.target_name with
+        | Some name -> ("TARGET_NAME=" ^ name) :: build_args
+        | _ -> build_args
+      in
+      let config = { conf with build_args } in
+      { Env.worker = conf.worker; image; dockerfile; clock; config })
     envs

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -10,6 +10,8 @@ module Benchmark : sig
     worker:string ->
     docker_image:string ->
     benchmark_name:string option ->
+    target_version:string option ->
+    target_name:string option ->
     test_index:int ->
     repository:Repository.t ->
     Yojson.Safe.t ->
@@ -20,6 +22,8 @@ module Benchmark : sig
   val duration : t -> Ptime.span
   val repo_id : t -> string * string
   val commit : t -> string
+  val target_version : t -> string option
+  val target_name : t -> string option
   val branch : t -> string option
   val pull_number : t -> int option
   val build_job_id : t -> string option

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -87,9 +87,12 @@ module Env = Custom_dockerfile.Env
 let pipeline ~config ~ocluster ~conninfo ~repository env =
   let worker = env.Env.worker in
   let docker_image = env.Env.image in
+  let target_version = env.Env.config.target_version in
+  let target_name = env.Env.config.target_name in
   let key = Config.key_of_repo ~config repository worker docker_image in
   let serial_id =
-    Storage.setup_metadata ~repository ~conninfo ~worker ~docker_image
+    Storage.setup_metadata ~repository ~target_version ~target_name ~conninfo
+      ~worker ~docker_image
   in
   let docker_options =
     {

--- a/pipeline/lib/storage.ml
+++ b/pipeline/lib/storage.ml
@@ -140,7 +140,7 @@ let record_target_info ~serial_id ~results (db : Postgresql.connection) =
     metadata
     (* FIXME: Check if all the versions and names are the same? *)
     |> List.hd
-    |> fun { Current_bench_json.Latest.target_version; target_name; _ } ->
+    |> fun { Cb_schema.S.target_version; target_name; _ } ->
     ( Option.value target_version ~default:"",
       Option.value target_name ~default:"" )
   in

--- a/pipeline/tests/api_test.ml
+++ b/pipeline/tests/api_test.ml
@@ -91,12 +91,13 @@ let empty_benchmarks =
         (fun ?expect query ->
           let expected =
             "INSERT INTO benchmark_metadata (run_at, repo_id, commit, \
-             commit_message, branch, pull_number, pr_title, worker, \
-             docker_image) VALUES (to_timestamp(XXX), 'myowner/myrepo', \
-             'abcd12345', NULL, 'main', NULL, NULL, 'remote', 'external') ON \
-             CONFLICT(repo_id, commit, worker, docker_image) DO UPDATE SET \
-             build_job_id = NULL, run_job_id = NULL, failed = false, cancelled \
-             = false, success = false, reason = NULL RETURNING id;"
+             target_version, target_name, commit_message, branch, pull_number, \
+             pr_title, worker, docker_image) VALUES (to_timestamp(XXX), \
+             'myowner/myrepo', 'abcd12345', '', '', NULL, 'main', NULL, NULL, \
+             'remote', 'external') ON CONFLICT(repo_id, commit, \
+             target_version, worker, docker_image) DO UPDATE SET build_job_id \
+             = NULL, run_job_id = NULL, failed = false, cancelled = false, \
+             success = false, reason = NULL RETURNING id;"
           in
           Alcotest.(check string) "setup metadata" expected query;
           assert (expect = None);


### PR DESCRIPTION
This is a PR that corresponds to the changes in https://github.com/art-w/ocaml-benching/pull/2. This is still a WIP for the UI/frontend, but the backend plumbing should be in place. 