### PR TITLE
Update obuilder dependency

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -2,8 +2,8 @@ FROM ocaml/opam:debian-ocaml-4.13 AS build
 RUN sudo apt-get update && sudo apt-get install libc6-dev libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
 RUN opam remote add origin 'https://opam.ocaml.org' --all-switches && opam remote remove default && opam update
 RUN opam install dune>=2.8 ppx_expect>=v0.14.1 prometheus ppx_sexp_conv dune-build-info lwt>=5.4.1 capnp-rpc-lwt>=1.2 capnp-rpc-net capnp-rpc-unix>=1.2 extunix>=0.3.2 logs conf-libev digestif>=0.8 fpath lwt-dllist prometheus-app=1.1 cohttp-lwt-unix sqlite3 psq mirage-crypto>=0.8.5 ppx_deriving ppx_deriving_yojson astring fmt>=0.8.9 cmdliner tar-unix>=2.0.0 yojson sexplib sha
-RUN mkdir src && cd src && git clone 'https://github.com/ocurrent/ocluster' && opam pin -yn ocluster
-RUN cd src && git clone 'https://github.com/ocurrent/obuilder' && opam pin -yn obuilder
+RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
+RUN mkdir src && cd src && git clone 'https://github.com/art-w/ocluster' && cd ocluster && git checkout 957b6e422befddc4274ab9421fae75bdced7b1e9 && opam pin -yn --with-version=dev .
 WORKDIR src/ocluster
 RUN opam install -y --deps-only ./ocluster.opam
 RUN opam config exec -- dune build \

--- a/pipeline/lib/custom_dockerfile.ml
+++ b/pipeline/lib/custom_dockerfile.ml
@@ -85,7 +85,7 @@ let install_opam_dependencies ~files =
             String.concat " "
               (List.map (fun filename -> "./" ^ filename) bench_opam)
       in
-      copy ~src:[ "--chown=opam:opam ./*.opam" ] ~dst:"./" ()
+      copy ~chown:"opam:opam" ~src:[ "./*.opam" ] ~dst:"./" ()
       @@ run "opam exec -- opam pin -y -n --with-version=dev ."
       @@ run "opam exec -- opam install -y --depext-only %s" targets
       @@ run "opam exec -- opam install -y --deps-only --with-test %s" targets
@@ -103,7 +103,7 @@ let dockerfile ~base ~files =
   @@ run "mkdir bench-dir && chown opam:opam bench-dir"
   @@ workdir "bench-dir"
   @@ install_opam_dependencies ~files
-  @@ copy ~src:[ "--chown=opam:opam ." ] ~dst:"." ()
+  @@ copy ~chown:"opam:opam" ~src:[ "." ] ~dst:"." ()
 
 let dockerfile ~base ~files = Dockerfile.crunch (dockerfile ~base ~files)
 

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -27,10 +27,10 @@ depends: [
   "yojson"
 ]
 pin-depends: [
-  [ "ocluster-worker.dev" "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07" ]
-  [ "ocluster-api.dev"    "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07" ]
-  [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9" ]
-  [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9" ]
+  [ "ocluster-worker.dev" "git+https://github.com/art-w/ocluster.git#957b6e422befddc4274ab9421fae75bdced7b1e9" ]
+  [ "ocluster-api.dev"    "git+https://github.com/art-w/ocluster.git#957b6e422befddc4274ab9421fae75bdced7b1e9" ]
+  [ "obuilder.dev"        "git+https://github.com/art-w/obuilder#a473fcb7be6c236e9ee61e6549a803525b8f4021" ]
+  [ "obuilder-spec.dev"   "git+https://github.com/art-w/obuilder#a473fcb7be6c236e9ee61e6549a803525b8f4021" ]
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
The production server rebooted during the break (?) and was unable to restart the services automatically following some api changes in our dependencies... I'm tempted to switch to git submodules as in the other CI projects, WDYT?
For similar reasons, the custom dockerfiles were now produced with the wrong syntax `COPY ["--chown=opam:opam ./*.opam", "./"]` instead of the correct `COPY --chown=opam:opam ["./*.opam", "./"]`