### PR TITLE
Added prod.sh script and streamlined dev.sh usage in the Makefile

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -92,12 +92,12 @@ For more details on Hasura see: <https://hasura.io/docs/1.0/graphql/manual/deplo
 
 ### Running commands in the docker containers
 
-The `scripts/` directory has a helper script `dc.sh` that makes it easy to run
+The `scripts/` directory has two helper scripts `dev.sh` and `prod.sh` that makes it easy to run
 `docker-compose` commands without having to manually provide the `--file`,
 `--env` and `--project-name` arguments.
 
 ```sh
-./scripts/dc.sh exec db psql -U docker
+./scripts/dev.sh exec db psql -U docker
 ```
 
 ### Restarting services upon source code changes
@@ -117,7 +117,7 @@ make rebuild-pipeline
 It is possible to start just the database and the front-end without starting the `pipeline` that watches repositories and runs benchmarks. This is useful to visualize benchmarks run elsewhere using current-bench's frontend. To run only the db, frontend and graphq-engine containers, run the following command:
 
 ```sh
-./scripts/dc.sh up --build frontend db graphql-engine db-migrate
+./scripts/dev.sh up --build frontend db graphql-engine db-migrate
 ```
 
 ## Inspecting the benchmark results in the database

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,14 @@
 .PHONY: start-production
 start-production: update-version-info validate-env
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/production.docker-compose.yaml \
-		--env-file=./environments/production.env \
-		up \
-		--detach \
-		--build
+	./scripts/prod.sh up --detach --build
 
 .PHONY: build-production
 build-production:
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/production.docker-compose.yaml \
-		--env-file=./environments/production.env \
-		build
+	./scripts/prod.sh build
 
 .PHONY: stop-production
 stop-production:
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/production.docker-compose.yaml \
-		--env-file=./environments/production.env \
-		down
+	./scripts/prod.sh down
 
 .PHONY: redeploy-production
 redeploy-production: \
@@ -51,46 +37,24 @@ clean-local-test-repo:
 
 .PHONY: start-development
 start-development: ./local-test-repo/.git update-version-info validate-env
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
-		up \
-		--remove-orphans \
-		--build
+	./scripts/dev.sh up --remove-orphans --build
 
 .PHONY: stop-development
 stop-development: ./local-test-repo/.git
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
-		down
+	./scripts/dev.sh down
 
 .PHONY: update-graphql-schema
 update-graphql-schema: ./local-test-repo/.git
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
-		exec frontend /app/scripts/update-graphql-schema.sh
+	./scripts/dev.sh exec frontend /app/scripts/update-graphql-schema.sh
 
 
 .PHONY: rebuild-pipeline
 rebuild-pipeline: ./local-test-repo/.git
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
-		up --detach --build pipeline
+	./scripts/dev.sh up --detach --build pipeline
 
 .PHONY: rebuild-frontend
 rebuild-frontend: ./local-test-repo/.git
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
-		up --detach --build frontend
+	./scripts/dev.sh up --detach --build frontend
 
 .PHONY: bench
 bench:
@@ -112,18 +76,12 @@ start-node-exporter:
 
 .PHONY: runtest
 runtest: ./local-test-repo/.git
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
+	./scripts/dev.sh \
 		exec pipeline bash -c 'cd /mnt/project; opam exec -- dune runtest'
 
 .PHONY: coverage
 coverage: ./local-test-repo/.git
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
+	./scripts/dev.sh \
 		exec pipeline bash -c \
 		'cd /mnt/project; opam exec -- dune runtest --instrument-with bisect_ppx --force; \
 		opam exec -- bisect-ppx-report summary --per-file; opam exec -- bisect-ppx-report html' \
@@ -135,8 +93,5 @@ local-make-bench: ./local-test-repo/.git
 
 .PHONY: migration
 migration:
-	docker-compose \
-		--project-name="current-bench" \
-		--file=./environments/development.docker-compose.yaml \
-		--env-file=./environments/development.env \
+	./scripts/dev.sh \
 		exec pipeline omigrate create --verbose --dir=/app/db/migrations $(NAME)

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Helper script to run docker-compose commands easily
+# Helper script to run development docker-compose commands easily
 
 # Ensure script is always run from the root of the repository
 cd $(dirname $0)/..

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Helper script to run production docker-compose commands easily
+
+# Ensure script is always run from the root of the repository
+cd $(dirname $0)/..
+
+docker-compose --project-name="current-bench" \
+               --file=./environments/production.docker-compose.yaml \
+               --env-file=./environments/production.env \
+               "$@"


### PR DESCRIPTION
This PR is the second one in the series of committing what was on the prod server.
The script `prod.sh` was added, and I renamed `dc.sh` to `dev.sh` to make it clear that one uses the development environment, while the other uses the production env. I also used those scripts in the Makefile wherever needed, to simplify future maintenance work.