### PR TITLE
Fix pins of ocluster & ocurrent in Dockerfile & .opam file

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,9 +1,9 @@
 FROM ocaml/opam:debian-ocaml-4.14 AS build
 RUN sudo apt-get update && sudo apt-get install libc6-dev libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
 RUN opam remote add origin 'https://opam.ocaml.org' --all-switches && opam remote remove default && opam update
+RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
 RUN opam install dune>=2.8 ppx_expect>=v0.14.1 prometheus ppx_sexp_conv dune-build-info lwt>=5.4.1 capnp-rpc-lwt>=1.2 capnp-rpc-net capnp-rpc-unix>=1.2 extunix>=0.3.2 logs conf-libev digestif>=0.8 fpath lwt-dllist prometheus-app=1.1 cohttp-lwt-unix sqlite3 psq mirage-crypto>=0.8.5 ppx_deriving ppx_deriving_yojson astring fmt>=0.8.9 cmdliner tar-unix>=2.0.0 yojson sexplib sha
-RUN mkdir src && cd src && git clone 'https://github.com/ocurrent/ocluster' && opam pin -yn ocluster
-RUN cd src && git clone 'https://github.com/ocurrent/obuilder' && opam pin -yn obuilder
+RUN mkdir src && cd src && git clone 'https://github.com/ocurrent/ocluster' && git clone 'https://github.com/ocurrent/obuilder' && opam pin -yn ocluster obuilder
 WORKDIR src/ocluster
 RUN opam install -y --deps-only ./ocluster.opam
 RUN opam config exec -- dune build \
@@ -16,6 +16,6 @@ RUN apt-get install ca-certificates -y  # https://github.com/mirage/ocaml-condui
 WORKDIR /var/lib/ocluster-scheduler
 ENTRYPOINT ["/usr/local/bin/ocluster-scheduler"]
 COPY --from=build \
-     /home/opam/src/ocluster/_build/install/default/bin/ocluster-scheduler \
-     /home/opam/src/ocluster/_build/install/default/bin/ocluster-admin \
-     /usr/local/bin/
+  /home/opam/src/ocluster/_build/install/default/bin/ocluster-scheduler \
+  /home/opam/src/ocluster/_build/install/default/bin/ocluster-admin \
+  /usr/local/bin/

--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -3,10 +3,11 @@ RUN sudo apt-get update && sudo apt-get install libc6-dev libev-dev capnproto m4
 RUN opam remote add origin 'https://opam.ocaml.org' --all-switches && opam remote remove default && opam update
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
 RUN opam install dune>=2.8 ppx_expect>=v0.14.1 prometheus ppx_sexp_conv dune-build-info lwt>=5.4.1 capnp-rpc-lwt>=1.2 capnp-rpc-net capnp-rpc-unix>=1.2 extunix>=0.3.2 logs conf-libev digestif>=0.8 fpath lwt-dllist prometheus-app=1.1 cohttp-lwt-unix sqlite3 psq mirage-crypto>=0.8.5 ppx_deriving ppx_deriving_yojson astring fmt>=0.8.9 cmdliner tar-unix>=2.0.0 yojson sexplib sha
-RUN mkdir src && cd src && git clone 'https://github.com/ocurrent/ocluster' && git clone 'https://github.com/ocurrent/obuilder' && opam pin -yn ocluster obuilder
+RUN mkdir src && cd src && git clone --recurse-submodules 'https://github.com/ocurrent/ocluster'
 WORKDIR src/ocluster
+RUN opam pin -yn .
 RUN opam install -y --deps-only ./ocluster.opam
-RUN opam config exec -- dune build \
+RUN opam exec -- dune build \
   ./_build/install/default/bin/ocluster-scheduler \
   ./_build/install/default/bin/ocluster-admin
 

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-11-ocaml-4.13 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14 AS build
 
 RUN sudo apt-get update && \
     sudo apt-get install -qq -yy \
@@ -33,21 +33,21 @@ ARG TARGET_ARCH=amd64
 
 RUN apt-get update \
     && apt-get install --no-install-recommends --assume-yes \
-        netbase \
-        ca-certificates \
-        apt-transport-https \
-        curl \
-        netcat \
-        postgresql-client \
-        gnupg \
-        lsb-release \
-        git \
-        libpq-dev \
-        libsqlite3-dev \
-        libev-dev \
+    netbase \
+    ca-certificates \
+    apt-transport-https \
+    curl \
+    netcat \
+    postgresql-client \
+    gnupg \
+    lsb-release \
+    git \
+    libpq-dev \
+    libsqlite3-dev \
+    libev-dev \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=${TARGET_ARCH} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-        > /etc/apt/sources.list.d/docker.list \
+    > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install docker-ce-cli graphviz --assume-yes \
     && rm -r /var/lib/apt/lists /var/cache/apt
@@ -57,8 +57,8 @@ ENV PATH="/app/bin:${PATH}"
 
 COPY ./pipeline/aslr_seccomp.json /app/aslr_seccomp.json
 COPY ./pipeline/db/migrations /app/db/migrations
-COPY --from=build /home/opam/.opam/4.13/bin/omigrate /app/bin/omigrate
-COPY --from=build /home/opam/.opam/4.13/bin/ocluster-admin /app/bin/ocluster-admin
+COPY --from=build /home/opam/.opam/4.14/bin/omigrate /app/bin/omigrate
+COPY --from=build /home/opam/.opam/4.14/bin/ocluster-admin /app/bin/ocluster-admin
 COPY --from=build /mnt/project/_build/default/bin/main.exe /app/bin/current-bench-pipeline
 COPY ./pipeline/entrypoint.sh /app/entrypoint.sh
 COPY ./environments/production.conf /app/production.conf

--- a/pipeline/Dockerfile.dev
+++ b/pipeline/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-11-ocaml-4.13 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14 AS build
 
 RUN sudo apt-get update && \
     sudo apt-get install -qq -yy \
@@ -28,23 +28,23 @@ ARG TARGET_ARCH=amd64
 
 RUN apt-get update \
     && apt-get install --no-install-recommends --assume-yes \
-        netbase \
-        ca-certificates \
-        apt-transport-https \
-        curl \
-        netcat \
-        postgresql-client \
-        gnupg \
-        lsb-release \
-        git \
-        libpq-dev \
-        libsqlite3-dev \
-        libev-dev \
-        inotify-tools \
-        procps \
+    netbase \
+    ca-certificates \
+    apt-transport-https \
+    curl \
+    netcat \
+    postgresql-client \
+    gnupg \
+    lsb-release \
+    git \
+    libpq-dev \
+    libsqlite3-dev \
+    libev-dev \
+    inotify-tools \
+    procps \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=${TARGET_ARCH} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-        > /etc/apt/sources.list.d/docker.list \
+    > /etc/apt/sources.list.d/docker.list \
     && ( curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc > /etc/apt/trusted.gpg.d/ngrok.asc ) \
     && ( echo "deb https://ngrok-agent.s3.amazonaws.com buster main" > /etc/apt/sources.list.d/ngrok.list ) \
     && apt-get update \
@@ -64,7 +64,7 @@ ENV PATH="/app/bin:${PATH}"
 COPY environments/ /mnt/environments/
 COPY pipeline/aslr_seccomp.json /app/aslr_seccomp.json
 COPY pipeline/db/migrations /app/db/migrations
-RUN cp /home/opam/.opam/4.13/bin/omigrate /app/bin/omigrate
-RUN cp /home/opam/.opam/4.13/bin/ocluster-admin /app/bin/ocluster-admin
+RUN cp /home/opam/.opam/4.14/bin/omigrate /app/bin/omigrate
+RUN cp /home/opam/.opam/4.14/bin/ocluster-admin /app/bin/ocluster-admin
 RUN cp /mnt/project/_build/default/bin/main.exe /app/bin/current-bench-pipeline
 COPY pipeline/entrypoint.sh /app/entrypoint.sh

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-11-ocaml-4.13 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14 AS build
 
 RUN sudo apt-get update && \
     sudo apt-get install -qq -yy \
@@ -33,20 +33,20 @@ ARG TARGET_ARCH=amd64
 
 RUN apt-get update \
     && apt-get install --no-install-recommends --assume-yes \
-        netbase \
-        ca-certificates \
-        apt-transport-https \
-        curl \
-        netcat \
-        gnupg \
-        lsb-release \
-        git \
-        libpq-dev \
-        libsqlite3-dev \
-        libev-dev \
+    netbase \
+    ca-certificates \
+    apt-transport-https \
+    curl \
+    netcat \
+    gnupg \
+    lsb-release \
+    git \
+    libpq-dev \
+    libsqlite3-dev \
+    libev-dev \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=${TARGET_ARCH} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-        > /etc/apt/sources.list.d/docker.list \
+    > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install docker-ce-cli graphviz --assume-yes \
     && rm -r /var/lib/apt/lists /var/cache/apt

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -29,9 +29,10 @@ depends: [
 pin-depends: [
   # This pin is necessary until ocurrent/ocluster/pull/151 is merged, as the ocluster-worker package doesn't exist yet on the main repo.
   [ "ocluster-worker.dev" "git+https://github.com/art-w/ocluster.git#public-worker" ]
-  [ "ocluster-api.dev"    "git+https://github.com/ocurrent/ocluster.git" ]
-  [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder" ]
-  [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder" ]
+  [ "ocluster-api.dev"    "git+https://github.com/art-w/ocluster.git#public-worker" ]
+  # This pin is necessary to build obuilder, but the commit SHA is kinda random. Remove if it builds fine on latest.
+  [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder#671a2400528f29736dc446813f0699055d8e631b" ]
+  [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder#671a2400528f29736dc446813f0699055d8e631b" ]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -27,10 +27,10 @@ depends: [
   "yojson"
 ]
 pin-depends: [
-  [ "ocluster-worker.dev" "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07" ]
-  [ "ocluster-api.dev"    "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07" ]
-  [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9" ]
-  [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9" ]
+  [ "ocluster-worker.dev" "git+https://github.com/ocurrent/ocluster.git#live-worker" ]
+  [ "ocluster-api.dev"    "git+https://github.com/ocurrent/ocluster.git#live-worker" ]
+  [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder" ]
+  [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder" ]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -27,8 +27,8 @@ depends: [
   "yojson"
 ]
 pin-depends: [
-  [ "ocluster-worker.dev" "git+https://github.com/ocurrent/ocluster.git#live-worker" ]
-  [ "ocluster-api.dev"    "git+https://github.com/ocurrent/ocluster.git#live-worker" ]
+  [ "ocluster-worker.dev" "git+https://github.com/ocurrent/ocluster.git" ]
+  [ "ocluster-api.dev"    "git+https://github.com/ocurrent/ocluster.git" ]
   [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder" ]
   [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder" ]
 ]

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -27,7 +27,8 @@ depends: [
   "yojson"
 ]
 pin-depends: [
-  [ "ocluster-worker.dev" "git+https://github.com/ocurrent/ocluster.git" ]
+  # This pin is necessary until ocurrent/ocluster/pull/151 is merged, as the ocluster-worker package doesn't exist yet on the main repo.
+  [ "ocluster-worker.dev" "git+https://github.com/art-w/ocluster.git#public-worker" ]
   [ "ocluster-api.dev"    "git+https://github.com/ocurrent/ocluster.git" ]
   [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder" ]
   [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder" ]


### PR DESCRIPTION
This PR is the third one in the series of committing/cleaning what was on the prod server.
~~There were pins on art-w/ocluster even though that repo isn't actively maintained.~~
Part of the pin actually made sense, as the package `ocluster-worker` isn't merged into the main branch yet, so I added a comment to specify when to remove the pin.

Another weird thing is the line `sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam`. This (AFAIK) forces the used version of opam to be 2.1 instead of the default 2.0. Why this change was made in the first place I don't really know, but there might be someone down the line assuming opam version to be 2.1 so better not change this without full knowledge