### PR TITLE
Cleaner json handling

### DIFF
--- a/cobench/cobench.ml
+++ b/cobench/cobench.ml
@@ -20,8 +20,8 @@ let of_metrics ~name ms = { L.test_name = name; metrics = ms }
 type t = L.t
 
 let of_results results = { L.benchmark_name = None; results }
-let to_json = C.to_json
-let of_json = C.of_json
+let to_json = L.to_json
+let of_json = L.of_json
 
 module Remote = struct
   type token = {

--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -56,7 +56,7 @@ module Benchmark = {
 
   let decode = (result: BenchmarkMetrics.t) => {
     let metrics = yojson_of_result(result)
-    let metrics = Current_bench_json.of_json(metrics)
+    let metrics = Current_bench_json.Latest.of_json(metrics)
     let run_at = result.run_at->decodeRunAt->Belt.Option.getExn
     (result.commit, result.run_job_id, run_at, result.test_index, metrics)
   }

--- a/pipeline/lib/api.ml
+++ b/pipeline/lib/api.ml
@@ -99,7 +99,7 @@ let make_benchmark_from_request ~conninfo ~body ~token =
     (benchmarks
     |> List.map (fun bench ->
            Json_stream.db_save ~conninfo benchmark
-             [ Current_bench_json.of_json bench ]));
+             [ Current_bench_json.Latest.of_json bench ]));
   Storage.record_success ~conninfo ~serial_id
 
 let error_message msg =

--- a/pipeline/lib/current_bench_json.ml
+++ b/pipeline/lib/current_bench_json.ml
@@ -283,7 +283,13 @@ let of_json json = Latest.of_json json
 let to_json t = Latest.to_json t
 
 let of_list jsons =
-  List.fold_left (fun acc json -> Latest.merge acc [ of_json json ]) [] jsons
+  List.fold_left
+    (fun acc json ->
+       match of_json json with
+       | t -> Latest.merge acc [t]
+       | exception _ -> acc)
+    []
+    jsons
 
 let to_list ts =
   List.map

--- a/pipeline/lib/current_bench_json.ml
+++ b/pipeline/lib/current_bench_json.ml
@@ -257,7 +257,7 @@ module V2 = struct
   let of_json t =
     let lines =
       match Json.get "lines" t with
-      | `Tuple [ `Int start; `Int end_ ] -> [ (start, end_) ]
+      | `Tuple [ `Int start; `Int finish ] -> [ (start, finish) ]
       | _ -> []
     in
     {
@@ -278,22 +278,17 @@ end
 
 module Latest = V2
 
-let version = 2
-let of_json json = Latest.of_json json
-let to_json t = Latest.to_json t
-
 let of_list jsons =
   List.fold_left
     (fun acc json ->
-       match of_json json with
-       | t -> Latest.merge acc [t]
+      match Latest.of_json json with
+      | t -> Latest.merge acc [ t ]
        | exception _ -> acc)
-    []
-    jsons
+    [] jsons
 
 let to_list ts =
   List.map
     (fun { Latest.benchmark_name; results } ->
       let results = List.map Latest.json_of_result results in
-      (benchmark_name, version, results))
+      (benchmark_name, Latest.version, results))
     ts

--- a/pipeline/lib/current_bench_json.ml
+++ b/pipeline/lib/current_bench_json.ml
@@ -294,14 +294,6 @@ end
 
 module Latest = V2
 
-let of_list jsons =
-  List.fold_left
-    (fun acc json ->
-      match Latest.of_json json with
-      | t -> Latest.merge acc [ t ]
-      | exception _ -> acc)
-    [] jsons
-
 let to_list ts =
   List.map
     (fun { Latest.benchmark_name; results } ->

--- a/pipeline/lib/json_stream.ml
+++ b/pipeline/lib/json_stream.ml
@@ -238,7 +238,7 @@ module Save = struct
             failures
         in
         let cb_output =
-          let jsons = List.map Current_bench_json.to_json cb in
+          let jsons = List.map Current_bench_json.Latest.to_json cb in
           "```" ^ Yojson.Safe.to_string (`List jsons) ^ "```"
         in
         String.concat "\n" ("" :: cb_output :: failures_output)


### PR DESCRIPTION
Note: this PR is the same as #391, I just renamed the original branch.
This PR is the fifth and last one in the series of committing/cleaning what was on the prod server.
The change to exception handling in json parsing should make it way easier to debug, and eventually resolve #265 & #385.