### PR TITLE
Upper bound on dune < 3.6 because it breaks obuilder

### DIFF
--- a/cobench.opam
+++ b/cobench.opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/ocurrent/current-bench.git"
 
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune"  {>= "2.0"}
+  "dune" {>= "2.0" & <= "3.5"}
   "yojson"
   "cohttp-lwt-unix"
   "odoc" {with-doc}

--- a/current-bench-bechamel/current-bench-bechamel.opam
+++ b/current-bench-bechamel/current-bench-bechamel.opam
@@ -5,7 +5,7 @@ authors: ["Rizo I. <rizo@tarides.com>"]
 homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & <= "3.5"}
   "bechamel"
   "yojson"
 ]

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/ocurrent/current-bench.git"
 
 depends: [
   "ocaml"   {>= "4.13.0"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & <= "3.5"}
   "yojson"
   "reason" {>= "dev"}
   "bechamel"

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & <= "3.5"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
   "bisect_ppx" {with-test}

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -8,7 +8,7 @@ authors: ["Rizo Isrof <rizo@tarides.com" "Craig Ferguson <craig@tarides.com>" "G
 homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & <= "3.5"}
   "capnp-rpc-unix"
   "cmdliner" {>= "1.1.0"}
   "dockerfile"


### PR DESCRIPTION
As per [the release notes](https://github.com/ocaml/dune/releases/tag/3.6.0), dune doesn't allow some private library shenanigans that happen in obuilder. This PR fixes that and allow current-bench to actually build.