### PR TITLE
Timeout on actual docker runners

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -284,7 +284,8 @@ let v ~config ~server:mode ~sources conninfo () =
     | Error (`Msg msg) -> failwith msg
     | Ok sr -> sr
   in
-  let ocluster = Current_ocluster.(v (Connection.create sr)) in
+  let timeout = Duration.of_hour 2 in
+  let ocluster = Current_ocluster.(v ~timeout (Connection.create sr)) in
   let pipeline = process_pipeline ~config ~ocluster ~conninfo ~sources in
   let engine = Current.Engine.create pipeline in
   let webhook =


### PR DESCRIPTION
Solves #400, this time hopefully for real.
The problem was that `docker run` doesn't actually run anything, it asks the docker daemon to do the job. Killing the parent process in case of a timeout wasn't doing the expected "termination on timeout" thing. By adding a switch hook to use `docker kill` to perform the cleanup works. Of course the runner needed to be named for this.