### PR TITLE
Replace deprecated Mtime.Span.to_ms with to_float_ns /. 1e6

### DIFF
--- a/cobench/cobench.ml
+++ b/cobench/cobench.ml
@@ -93,7 +93,7 @@ let pr_bench value =
 let time (f : unit -> 'a) =
   let t = Mtime_clock.counter () in
   let _ = f () in
-  Mtime.Span.to_ms (Mtime_clock.count t)
+  Mtime.Span.to_float_ns (Mtime_clock.count t) /. 1e6
 
 let test_bench f = Test.make ~name:"" (Staged.stage @@ f)
 


### PR DESCRIPTION
We pull mtime version 2.0.0 with some of our dependencies.
`Mtime.Span.to_ms` has been removed in version 2.0, and using `to_float_ns` seems to be the replacement. This should fix the CI