### PR TITLE
Added _opam to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 local-test-repo/.git
 *.env
 _build
+_opam
 _coverage
 environments/cb-dev-test.pem
 environments/github.secret


### PR DESCRIPTION
This helps avoid the "this repo has too many modifications, git may not fully work" warning when using a local opam switch