### PR TITLE
Use literal value in json format example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To be able to draw graphs from your results, they need to follow this format:
     {
       "name": "name-of-the-test",
       "metrics": [
-        {"name": "benchmark-name", "value": "benchmark-value", "units": "benchmark-unit", "description": "benchmark-description"},
+        {"name": "benchmark-name", "value": 42, "units": "benchmark-unit", "description": "benchmark-description"},
         {"name": "num_ops", "value": [0.5, 1.5, ...], "units": "ops/sec", "description": "total number of ops", "trend": "lower-is-better"},
         {"name": "time", "value": 20, "units": "sec", "description": "time for action"},
         {"name": "data-transfer", "value": {"min": 1, "max": 25.2, "avg": 19.8}, "units": "mbps", "description": "data transfer per second", "trend": "higher-is-better"},


### PR DESCRIPTION
I imagine there is a tendency to copy this example when making one's first benchmark, and removing the obvious placeholders (the ellipses). The problem with including `"value": "benchmark-value"` in the format example is that it is valid json but isn't accepted by current-bench, so it may take a while for people to realize that this is the reason their benchmarks aren't producing graphs.