### PR TITLE
Checking docker runs before trying to kill it

### DIFF
--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -23,7 +23,7 @@ type api_token_list = api_token list [@@deriving yojson]
 type config = {
   repositories : repo_list;
   api_tokens : api_token_list;
-  slack : (string option[@default None]);
+  slack : string option; [@default None]
 }
 [@@deriving yojson]
 

--- a/worker/.ocamlformat
+++ b/worker/.ocamlformat
@@ -1,0 +1,1 @@
+../pipeline/.ocamlformat

--- a/worker/cb_worker.ml
+++ b/worker/cb_worker.ml
@@ -129,10 +129,12 @@ let docker_run ~switch ~log ~docker_config ~cpu img_hash =
     @ run_command ~arch:docker_config.arch
   in
   Lwt_switch.add_hook_or_exec (Some switch) (fun () ->
-      Lwt_unix.system ("docker ps -q | grep -q " ^ name) >>= function
-      | Unix.WEXITED 0 ->
-          Lwt_unix.system ("docker kill " ^ name) >>= fun _ -> Lwt.return_unit
-      | _ -> Lwt.return_unit)
+      Lwt_process.pread ("docker", [| "docker"; "ps"; "-qf"; "name=" ^ name |])
+      >>= function
+      | "" -> Lwt.return_unit
+      | _ ->
+          Lwt_process.exec ("docker", [| "docker"; "kill"; name |]) >>= fun _ ->
+          Lwt.return_unit)
   >>= fun () -> Process.check_call ~label:"docker-run" ~switch ~log command
 
 let docker_run ~switch ~log ~docker_config img_hash =

--- a/worker/cb_worker.ml
+++ b/worker/cb_worker.ml
@@ -129,7 +129,10 @@ let docker_run ~switch ~log ~docker_config ~cpu img_hash =
     @ run_command ~arch:docker_config.arch
   in
   Lwt_switch.add_hook_or_exec (Some switch) (fun () ->
-      Lwt_unix.system ("docker kill " ^ name) >>= fun _ -> Lwt.return_unit)
+      Lwt_unix.system ("docker ps -q | grep -q " ^ name) >>= function
+      | Unix.WEXITED 0 ->
+          Lwt_unix.system ("docker kill " ^ name) >>= fun _ -> Lwt.return_unit
+      | _ -> Lwt.return_unit)
   >>= fun () -> Process.check_call ~label:"docker-run" ~switch ~log command
 
 let docker_run ~switch ~log ~docker_config img_hash =


### PR DESCRIPTION
This removes a slightly annoying warning:
 `worker_1 | Error response from daemon: Cannot kill container: cb_worker_runner_0: No such container: cb_worker_runner_0`
We first check if `docker ps` finds that container before `kill`ing it.