### PR TITLE
Allow dockerfiles to exist anywhere, and there can be multiple ones

### DIFF
--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -9,6 +9,7 @@ type repo = {
   name : string;
   worker : string; [@default default_worker]
   image : string; [@default default_docker]
+  dockerfile : string option; [@default None]
   schedule : string option; [@default None]
   build_args : string list; [@default []]
   notify_github : bool; [@default false]
@@ -92,6 +93,7 @@ let default name =
     name;
     worker = default_worker;
     image = default_docker;
+    dockerfile = None;
     schedule = None;
     build_args = [];
     notify_github = false;


### PR DESCRIPTION
This PR solves #395.
Users can tell us where their dockerfile is, and we'll setup a `"dockerfile": "path/to/dockerfile"` in `production.conf` and it should be good to go.

If they want to have multiple dockerfiles, it's now possible:
```json
{
  "name": "org/repo",
  "dockerfile": "path/to/normal/dockerfile"
},
{
  "name": "org/repo",
  "dockerfile": "path/to/other/dockerfile"
}
```
Tested locally and everything seems to be in order.