### PR TITLE
OCluster 0.2.1 packages

### DIFF
--- a/cobench.opam
+++ b/cobench.opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/ocurrent/current-bench.git"
 
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.0" & <= "3.5"}
+  "dune" {>= "2.0"}
   "yojson"
   "cohttp-lwt-unix"
   "odoc" {with-doc}

--- a/current-bench-bechamel/current-bench-bechamel.opam
+++ b/current-bench-bechamel/current-bench-bechamel.opam
@@ -5,7 +5,7 @@ authors: ["Rizo I. <rizo@tarides.com>"]
 homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
-  "dune" {>= "2.0" & <= "3.5"}
+  "dune" {>= "2.8"}
   "bechamel"
   "yojson"
 ]

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -24,11 +24,11 @@ depends: [
   "current_web"    {>= "0.6.4"}
   "current_incr" {>= "0.5"}
   "current_ansi"
-  "current_ocluster" {= "dev"}
-  "ocluster-api"     {= "dev"}
-  "ocluster-worker"  {= "dev"}
-  "obuilder"         {= "dev"}
-  "obuilder-spec"    {= "dev"}
+  "current_ocluster" {>= "0.2.1"}
+  "ocluster-api"     {>= "0.2.1"}
+  "ocluster-worker"  {>= "0.2.1"}
+  "obuilder"         {>= "0.5.1"}
+  "obuilder-spec"    {>= "0.5.1"}
   "dockerfile"
   "duration"
   "fpath"
@@ -45,11 +45,6 @@ depends: [
 
 pin-depends: [
   [ "reason.dev" "git+https://github.com/reasonml/reason.git#ccc34729994b4a80d4f6274cc0165cd9113444d6"]
-  [ "current_ocluster.dev" "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07"]
-  [ "ocluster-api.dev"     "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07"]
-  [ "ocluster-worker.dev"  "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07"]
-  [ "obuilder.dev"         "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9"]
-  [ "obuilder-spec.dev"    "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9"]
 ]
 
 depexts: [

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -34,7 +34,7 @@ depends: [
   "fpath"
   "logs"
   "postgresql"
-  "prometheus-app" {= "1.2"}
+  "prometheus-app" {>= "1.2"}
   "rresult"
   "omigrate"
   "timere"

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/ocurrent/current-bench.git"
 
 depends: [
   "ocaml"   {>= "4.13.0"}
-  "dune" {>= "2.0" & <= "3.5"}
+  "dune" {>= "2.0"}
   "yojson"
   "reason" {>= "dev"}
   "bechamel"

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -24,7 +24,8 @@ depends: [
   "current_web"    {>= "0.6.4"}
   "current_incr" {>= "0.5"}
   "current_ansi"
-  "current_ocluster" {= "dev"}
+  "current_ocluster" {>= "0.2.1"}
+  "ocluster" {>= "0.2.1"}
   "dockerfile"
   "duration"
   "fpath"
@@ -33,17 +34,8 @@ depends: [
   "ptime" {>= "0.8.1"}
   "rresult"
   "omigrate"
-  "ocluster" {= "dev"}
   "timere"
   "timere-parse"
-]
-pin-depends: [
-  [ "current_ocluster.dev" "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07"]
-  [ "ocluster.dev"         "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07"]
-  [ "ocluster-api.dev"     "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07"]
-  [ "ocluster-worker.dev"  "git+https://github.com/art-w/ocluster.git#e32a5022b90c288a14947520a77bdc2ab7789a07"]
-  [ "obuilder.dev"         "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9"]
-  [ "obuilder-spec.dev"    "git+https://github.com/ocurrent/obuilder#dc987c12ccc6cd9729809359e9375bfe5443add9"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.0" & <= "3.5"}
+  "dune" {>= "2.0"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
   "bisect_ppx" {with-test}

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -12,11 +12,11 @@ depends: [
   "capnp-rpc-unix"
   "cmdliner" {>= "1.1.0"}
   "dockerfile"
-  "prometheus-app"  {= "1.2"}
   "ocluster-worker" {>= "0.2.1"}
   "ocluster-api"    {>= "0.2.1"}
   "obuilder"        {>= "0.5.1"}
   "obuilder-spec"   {>= "0.5.1"}
+  "prometheus-app"  {>= "1.2"}
   "fpath"
   "logs"
   "ocaml" {>= "4.08"}

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -12,11 +12,11 @@ depends: [
   "capnp-rpc-unix"
   "cmdliner" {>= "1.1.0"}
   "dockerfile"
-  "ocluster-worker" {= "dev"}
-  "ocluster-api"    {= "dev"}
-  "obuilder"        {= "dev"}
-  "obuilder-spec"   {= "dev"}
   "prometheus-app"  {= "1.2"}
+  "ocluster-worker" {>= "0.2.1"}
+  "ocluster-api"    {>= "0.2.1"}
+  "obuilder"        {>= "0.5.1"}
+  "obuilder-spec"   {>= "0.5.1"}
   "fpath"
   "logs"
   "ocaml" {>= "4.08"}
@@ -25,14 +25,6 @@ depends: [
   "sqlite3"
   "tar-unix"
   "yojson"
-]
-pin-depends: [
-  # This pin is necessary until ocurrent/ocluster/pull/151 is merged, as the ocluster-worker package doesn't exist yet on the main repo.
-  [ "ocluster-worker.dev" "git+https://github.com/art-w/ocluster.git#public-worker" ]
-  [ "ocluster-api.dev"    "git+https://github.com/art-w/ocluster.git#public-worker" ]
-  # This pin is necessary to build obuilder, but the commit SHA is kinda random. Remove if it builds fine on latest.
-  [ "obuilder.dev"        "git+https://github.com/ocurrent/obuilder#671a2400528f29736dc446813f0699055d8e631b" ]
-  [ "obuilder-spec.dev"   "git+https://github.com/ocurrent/obuilder#671a2400528f29736dc446813f0699055d8e631b" ]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/worker/cb-worker.opam
+++ b/worker/cb-worker.opam
@@ -8,7 +8,7 @@ authors: ["Rizo Isrof <rizo@tarides.com" "Craig Ferguson <craig@tarides.com>" "G
 homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
-  "dune" {>= "2.0" & <= "3.5"}
+  "dune" {>= "2.9"}
   "capnp-rpc-unix"
   "cmdliner" {>= "1.1.0"}
   "dockerfile"


### PR DESCRIPTION
Updating to OCluster 0.2.1 packages, I've noticed that Dune lower bounds were out of sync between opam files and `dune-project`. I'm also testing whether the upper bound to Dune 3.5 can be lifted (btw, I suggest moving to Dune 3, which enables more warnings). Lifting the constraint on prometheus-app from `= 1.2` to `>= 1.2` will also allow benefiting from future patch releases.
There might be other updates needed, perhaps to deployment Dockerfiles (such as the opam-repository sha (in which case I suggest https://github.com/ocaml/opam-repository/commit/c59aec93bab15c48f633a83cea5344ddbfbf5556)).