### PR TITLE
Moving to latest dune

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ frontend/node_modules
 current-bench-bechamel
 scripts
 capnp-secrets
+pipeline/_build

--- a/cb-check.opam
+++ b/cb-check.opam
@@ -6,7 +6,7 @@ authors: ["Ambre Austen Suhamy <ambre@tarides.com>"]
 homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.7"}
   "ocaml" {>= "4.13.0"}
   "yojson"
   "odoc" {with-doc}
@@ -20,11 +20,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocurrent/current-bench.git"

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.9"}
+  "dune" {>= "3.7"}
   "bechamel"
   "bos"
   "capnp-rpc-unix"
@@ -57,12 +57,10 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocurrent/current-bench.git"
 depexts: [

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.9)
+(lang dune 3.7)
 
 (name current-bench)
 
@@ -15,6 +15,7 @@
   "Ambre Austen Suhamy <ambre@tarides.com>"
   "Puneeth Chaganti <puneeth@tarides.com>"
   "Shakthi Kannan <shakthi@tarides.com>")
+ (allow_empty)
  (depends
   (ocaml
    (>= 4.13.0))

--- a/environments/development.docker-compose.yaml
+++ b/environments/development.docker-compose.yaml
@@ -77,7 +77,6 @@ services:
     command:
       - "/app/entrypoint.sh"
       - "/mnt/project/reload.sh"
-      - "/app/bin/current-bench-pipeline"
       - "--repositories=/mnt/environments/development.conf"
       - "--local-repo-dir=/app/local-repo-dir"
       - "--verbose"

--- a/pipeline/dune-project
+++ b/pipeline/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.9)
+(lang dune 3.7)
 
 (name pipeline)
 

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -2,43 +2,52 @@ opam-version: "2.0"
 synopsis: "OCurrent pipeline for index benchmarks"
 description:
   "This pipeline runs the index benchmarks and publishes them to slack."
-maintainer: ["Rizo Isrof <rizo@tarides.com>" "Gargi Sharma <gargi@tarides.com>"]
-authors: ["Rizo Isrof <rizo@tarides.com" "Craig Ferguson <craig@tarides.com>" "Gargi Sharma <gargi@tarides.com>"]
+maintainer: [
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Puneeth Chaganti <puneeth@tarides.com>"
+  "Shakthi Kannan <shakthi@tarides.com>"
+]
+authors: [
+  "Rizo Isrof <rizo@tarides.com"
+  "Craig Ferguson <craig@tarides.com>"
+  "Gargi Sharma <gargi@tarides.com>"
+]
 homepage: "https://github.com/ocurrent/current-bench"
 bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.0"}
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
-  "bisect_ppx" {with-test}
+  "dune" {>= "3.7"}
   "bos"
   "capnp-rpc-unix"
   "cmdliner" {>= "1.1.0"}
-  "current"        {>= "0.6.4"}
-  "current_docker" {>= "0.6.4"}
-  "current_git"    {>= "0.6.4"}
-  "current_github" {>= "0.6.4"}
-  "current_rpc"    {>= "0.6.4"}
-  "current_slack"  {>= "0.6.4"}
-  "current_web"    {>= "0.6.4"}
-  "current_incr" {>= "0.5"}
+  "current" {>= "0.6.4"}
   "current_ansi"
+  "current_docker" {>= "0.6.4"}
+  "current_git" {>= "0.6.4"}
+  "current_github" {>= "0.6.4"}
+  "current_incr" {>= "0.5"}
   "current_ocluster" {>= "0.2.1"}
-  "ocluster" {>= "0.2.1"}
+  "current_rpc" {>= "0.6.4"}
+  "current_slack" {>= "0.6.4"}
+  "current_web" {>= "0.6.4"}
   "dockerfile" {>= "6.3.0"}
   "duration"
   "fpath"
   "logs"
+  "ocluster" {>= "0.2.1"}
+  "omigrate"
   "postgresql"
   "ptime" {>= "0.8.1"}
   "rresult"
-  "omigrate"
   "timere" {>= "0.5.0"}
   "timere-parse"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "bisect_ppx" {with-test}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/pipeline/reload.sh
+++ b/pipeline/reload.sh
@@ -1,33 +1,8 @@
 #!/bin/bash
+set -eu
 
-COMMAND="${*@Q}"
+cd /mnt/project
 
-DIR=_build/default/bin
-EXE="${DIR}/main.exe"
+./dev/github-app.sh
 
-function run {
-  cd /app
-  sh -c "$COMMAND" &
-  cd /mnt/project
-}
-
-run
-
-dune build --watch bin/main.exe &
-
-/mnt/project/dev/github-app.sh
-
-while :
-do
-  # NOTE:
-  # 1. inotifywait exits with a failure status code when main.exe gets deleted
-  #    before a rebuild. So, we watch the directory instead, and make sure the
-  #    file exists.
-  # 2. Also, we sleep for a short while, to ensure the process has been killed
-  #    before copying the new executable and trying to run it.
-  inotifywait -q -e CLOSE_WRITE "${DIR}" | grep -q main.exe \
-  && (pkill -f '^/app/bin/current-bench-pipeline' || echo 'Not running?') \
-  && sleep 0.1 \
-  && cp "${EXE}" /app/bin/current-bench-pipeline \
-  && run
-done
+dune exec --watch bin/main.exe -- "$@"


### PR DESCRIPTION
Since #420, if building using the latest versions of dune (above `3.5.0`), we had an error in the pipeline:
```
Error: A running dune (pid: 861738) instance has locked the build directory.
If this is not the case, please delete _build/.lock
```
This is because in `pipeline/reload.sh` we use `dune build --watch` **and then** call `dev/github-app.sh`, which calls `dune build`. This workflow has been made impossible in dune 3.6 and up with the use of lockfiles.

The simplest fix was to use `dune exec --watch`, introduced in the latest version of dune (`3.7.0`), and to call `dev/github-app.sh` **before** the call to watch.
Using the latest dune version introduced a bit of noise, sorry for that.