### PR TITLE
Support using a separate benchmarks repo for benchmarks

### DIFF
--- a/environments/development.conf
+++ b/environments/development.conf
@@ -3,7 +3,8 @@
     {
       "name": "local/test",
       "worker": "autumn",
-      "image": "ocaml/opam:debian-11-ocaml-4.14"
+      "image": "ocaml/opam:debian-11-ocaml-4.14",
+      "bench_repo": "https://github.com/ocurrent/current-bench"
     },
     {
       "name": "local/test",

--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -14,6 +14,7 @@ type repo = {
   build_args : string list; [@default []]
   notify_github : bool; [@default false]
   if_label : string option; [@default None]
+  bench_repo : string option; [@default None]
 }
 [@@deriving yojson]
 
@@ -98,6 +99,7 @@ let default name =
     build_args = [];
     notify_github = false;
     if_label = None;
+    bench_repo = None;
   }
 
 let must_benchmark repo conf =


### PR DESCRIPTION
For repositories like ocaml/ocaml, we would like the benchmarks to be maintained potentially by a bigger/different set of users, than the ocaml/ocaml maintainers. This commit adds support for an additional configuration variable that lets us clone an additional repository and run benchmarks from within it.

NOTE: No new benchmark runs would be triggered by any changes to the benchmarks repository, with this setup.

This is a simplistic PR that attempts to implement functionality similar to #370 without the UI hackery.