### PR TITLE
Filter out branches for benchmarking before setting up metadata

### DIFF
--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -111,7 +111,7 @@ let find t repo =
   let name = Repository.info repo in
   match List.filter (fun r -> r.name = name) t.repos with
   | [] -> [ default name ]
-  | configs -> List.filter (must_benchmark repo) configs
+  | configs -> configs
 
 let find_image t image_name = Images.find image_name t.images
 


### PR DESCRIPTION
Previously, we filtered out the branches which don't have the required label, before starting the benchmarking run. But, this meant that the metadata for the branch is already saved to the DB and displayed in the UI. This commit changes the filtering to be run before the metadata for the benchmark run is setup.