### PR TITLE
Support running benchmarks on multiple long-standing branches of a repository

### DIFF
--- a/frontend/graphql_schema.json
+++ b/frontend/graphql_schema.json
@@ -2687,6 +2687,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "type": {
               "kind": "SCALAR",
@@ -3371,6 +3383,16 @@
             "description": null
           },
           {
+            "name": "pull_base",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "pull_number",
             "defaultValue": null,
             "type": {
@@ -3606,6 +3628,16 @@
             "description": null
           },
           {
+            "name": "pull_base",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "pull_number",
             "defaultValue": null,
             "type": {
@@ -3781,6 +3813,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "type": {
               "kind": "SCALAR",
@@ -3915,6 +3959,16 @@
           },
           {
             "name": "pr_title",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_base",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -4089,6 +4143,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "type": {
               "kind": "SCALAR",
@@ -4223,6 +4289,16 @@
           },
           {
             "name": "pr_title",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_base",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -4546,6 +4622,16 @@
             "description": null
           },
           {
+            "name": "pull_base",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "pull_number",
             "defaultValue": null,
             "type": {
@@ -4719,6 +4805,12 @@
           {
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "description": "column name"
           },
@@ -4856,6 +4948,16 @@
           },
           {
             "name": "pr_title",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_base",
             "defaultValue": null,
             "type": {
               "kind": "SCALAR",
@@ -5277,6 +5379,12 @@
           {
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "description": "column name"
           },
@@ -5630,6 +5738,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_base",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "description": null
@@ -6359,6 +6479,16 @@
             "description": null
           },
           {
+            "name": "pull_base",
+            "defaultValue": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "pull_number",
             "defaultValue": null,
             "type": {
@@ -6645,6 +6775,16 @@
             "description": null
           },
           {
+            "name": "pull_base",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "pull_number",
             "defaultValue": null,
             "type": {
@@ -6806,6 +6946,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "type": {
               "kind": "SCALAR",
@@ -6944,6 +7096,16 @@
           },
           {
             "name": "docker_image",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_base",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -7114,6 +7276,18 @@
             "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "args": [],
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "type": {
               "kind": "SCALAR",
@@ -7252,6 +7426,16 @@
           },
           {
             "name": "docker_image",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_base",
             "defaultValue": null,
             "type": {
               "kind": "ENUM",
@@ -7565,6 +7749,16 @@
             "description": null
           },
           {
+            "name": "pull_base",
+            "defaultValue": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
             "name": "pull_number",
             "defaultValue": null,
             "type": {
@@ -7726,6 +7920,12 @@
           {
             "isDeprecated": false,
             "deprecationReason": null,
+            "name": "pull_base",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
             "name": "pull_number",
             "description": "column name"
           },
@@ -7843,6 +8043,16 @@
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
+              "ofType": null
+            },
+            "description": null
+          },
+          {
+            "name": "pull_base",
+            "defaultValue": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "description": null
@@ -8335,6 +8545,12 @@
             "isDeprecated": false,
             "deprecationReason": null,
             "name": "metrics",
+            "description": "column name"
+          },
+          {
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "name": "pull_base",
             "description": "column name"
           },
           {

--- a/frontend/src/BenchmarkQueryHelpers.res
+++ b/frontend/src/BenchmarkQueryHelpers.res
@@ -16,8 +16,8 @@ fragment BenchmarkMetrics on benchmarks {
 module GetBenchmarks = %graphql(`
 query ($repoId: String!,
        $pullNumber: Int,
+       $pullBase: String,
        $branch: String,
-       $defaultBranch: String!,
        $isMaster: Boolean!,
        $worker: String,
        $dockerImage: String,
@@ -40,7 +40,7 @@ query ($repoId: String!,
   }
   comparisonBenchmarks:
     benchmarks(where: {_and: [{pull_number: {_is_null: true}},
-                              {branch: {_eq: $defaultBranch}},
+                              {branch: {_eq: $pullBase}},
                               {repo_id: {_eq: $repoId}},
                               {worker: {_eq: $worker}},
                               {docker_image: {_eq: $dockerImage}},

--- a/frontend/src/BenchmarkQueryHelpers.res
+++ b/frontend/src/BenchmarkQueryHelpers.res
@@ -9,12 +9,15 @@ fragment BenchmarkMetrics on benchmarks {
   run_job_id
   worker
   docker_image
+  branch
 }
 `)
 
 module GetBenchmarks = %graphql(`
 query ($repoId: String!,
        $pullNumber: Int,
+       $branch: String,
+       $defaultBranch: String!,
        $isMaster: Boolean!,
        $worker: String,
        $dockerImage: String,
@@ -25,6 +28,7 @@ query ($repoId: String!,
   benchmarks:
     benchmarks(where: {_and: [{pull_number: {_eq: $pullNumber}},
                               {pull_number: {_is_null: $isMaster}},
+                              {branch: {_eq: $branch}},
                               {repo_id: {_eq: $repoId}},
                               {worker: {_eq: $worker}},
                               {docker_image: {_eq: $dockerImage}},
@@ -36,6 +40,7 @@ query ($repoId: String!,
   }
   comparisonBenchmarks:
     benchmarks(where: {_and: [{pull_number: {_is_null: true}},
+                              {branch: {_eq: $defaultBranch}},
                               {repo_id: {_eq: $repoId}},
                               {worker: {_eq: $worker}},
                               {docker_image: {_eq: $dockerImage}},

--- a/hasura-server/metadata/tables.yaml
+++ b/hasura-server/metadata/tables.yaml
@@ -11,6 +11,7 @@
       - commit
       - branch
       - pull_number
+      - pull_base
       - benchmark_name
       - test_name
       - test_index
@@ -35,6 +36,7 @@
       - commit_message
       - branch
       - pull_number
+      - pull_base
       - is_open_pr
       - build_job_id
       - run_job_id

--- a/pipeline/db/migrations/20230406110951_add_pull_base_column.down.sql
+++ b/pipeline/db/migrations/20230406110951_add_pull_base_column.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE benchmark_metadata DROP COLUMN pull_base;
+ALTER TABLE benchmarks DROP COLUMN pull_base;

--- a/pipeline/db/migrations/20230406110951_add_pull_base_column.up.sql
+++ b/pipeline/db/migrations/20230406110951_add_pull_base_column.up.sql
@@ -1,0 +1,39 @@
+ALTER TABLE benchmark_metadata ADD pull_base varchar(100);
+ALTER TABLE benchmarks ADD pull_base varchar(100);
+
+WITH default_branches (repo_id, pull_base) AS (VALUES
+('odis-labs/streaming', 'master'),
+('art-w/ocaml-benching', 'master'),
+('gridbugs/dune-monorepo-bench', 'main'),
+('Zineb-Ada/merlin', 'master'),
+('ocaml-multicore/kcas', 'main'),
+('mirage/irmin', 'main'),
+('ocaml-community/yojson', 'master'),
+('art-w/cb-dev-test', 'master'),
+('punchagan/current-bench', 'main'),
+('mirage/repr', 'main'),
+('mirage/index', 'main'),
+('ocaml-ppx/ppxlib', 'main'),
+('Zineb-Ada/bechamel-fact', 'master'),
+('ocaml-bench/sandmark', 'main'),
+('ocaml/dune', 'main'),
+('ElectreAAS/sandmark', 'main'),
+('ocaml-multicore/lockfree', 'main'),
+('Lucccyo/cachecache', 'main'),
+('ocaml-ppx/ocamlformat', 'main'),
+('art-w/ocaml', 'cb-comanche'),
+('Zineb-Ada/eqaf', 'master'),
+('ocaml/merlin', 'master'),
+('ElectreAAS/Paradict', 'master')
+),
+update_metadata AS (
+  UPDATE benchmark_metadata
+  SET pull_base = default_branches.pull_base
+  FROM default_branches
+  WHERE benchmark_metadata.repo_id = default_branches.repo_id
+  RETURNING benchmark_metadata.repo_id
+)
+UPDATE benchmarks
+SET pull_base = default_branches.pull_base
+FROM default_branches
+WHERE benchmarks.repo_id = default_branches.repo_id;

--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -14,6 +14,7 @@ type repo = {
   build_args : string list; [@default []]
   notify_github : bool; [@default false]
   if_label : string option; [@default None]
+  branches : string list; [@default []]
   bench_repo : string option; [@default None]
 }
 [@@deriving yojson]
@@ -99,10 +100,16 @@ let default name =
     build_args = [];
     notify_github = false;
     if_label = None;
+    branches = [];
     bench_repo = None;
   }
 
-let must_benchmark repo conf =
+let must_benchmark_branch ~default_branch ~branch conf =
+  match conf.branches with
+  | [] -> branch = default_branch
+  | branches -> List.mem branch branches
+
+let must_benchmark_pull repo conf =
   match (conf.if_label, Repository.pull_number repo) with
   | Some tag, Some _ -> List.mem tag (Repository.labels repo)
   | _ -> true

--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -111,7 +111,7 @@ let find t repo =
   let name = Repository.info repo in
   match List.filter (fun r -> r.name = name) t.repos with
   | [] -> [ default name ]
-  | configs -> List.filter (must_benchmark repo) configs
+  | configs -> configs
 
 let find_image t image_name = Images.find image_name t.images
 

--- a/pipeline/lib/models.ml
+++ b/pipeline/lib/models.ml
@@ -7,6 +7,7 @@ module Benchmark = struct
     commit : string;
     branch : string option;
     pull_number : int option;
+    pull_base : string option;
     build_job_id : string option;
     run_job_id : string option;
     worker : string;
@@ -30,6 +31,7 @@ module Benchmark = struct
       commit = Repository.commit_hash repository;
       branch = Repository.branch repository;
       pull_number = Repository.pull_number repository;
+      pull_base = Repository.pull_base repository;
       build_job_id;
       run_job_id;
       worker;
@@ -47,6 +49,7 @@ module Benchmark = struct
   let commit self = self.commit
   let branch self = self.branch
   let pull_number self = self.pull_number
+  let pull_base self = self.pull_base
   let build_job_id self = self.build_job_id
   let run_job_id self = self.run_job_id
   let test_name self = self.test_name
@@ -67,6 +70,7 @@ module Benchmark = struct
         field "commit" commit Fmt.string;
         field "branch" branch Fmt.(option string);
         field "pull_number" pull_number Fmt.(option int);
+        field "pull_base" pull_base Fmt.(option string);
         field "build_job_id" build_job_id Fmt.(option string);
         field "run_job_id" run_job_id Fmt.(option string);
         field "worker" worker Fmt.string;
@@ -88,6 +92,7 @@ module Benchmark = struct
       let commit = Db_util.string self.commit in
       let branch = Db_util.(option string) self.branch in
       let pull_number = Db_util.(option int) self.pull_number in
+      let pull_base = Db_util.(option string) self.pull_base in
       let build_job_id = Db_util.(option string) self.build_job_id in
       let run_job_id = Db_util.(option string) self.run_job_id in
       let benchmark_name = Db_util.string self.benchmark_name in
@@ -97,12 +102,12 @@ module Benchmark = struct
       let worker = Db_util.string self.worker in
       let docker_image = Db_util.string self.docker_image in
       Fmt.str
-        {|INSERT INTO benchmarks(version, run_at, duration, repo_id, commit, branch, pull_number, build_job_id, run_job_id, worker, docker_image, benchmark_name, test_name,  test_index, metrics)
-          VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        {|INSERT INTO benchmarks(version, run_at, duration, repo_id, commit, branch, pull_number, pull_base, build_job_id, run_job_id, worker, docker_image, benchmark_name, test_name,  test_index, metrics)
+          VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
           ON CONFLICT (commit, benchmark_name, test_name, run_job_id)
           DO UPDATE SET metrics = EXCLUDED.metrics
         |}
-        version run_at duration repository commit branch pull_number
+        version run_at duration repository commit branch pull_number pull_base
         build_job_id run_job_id worker docker_image benchmark_name test_name
         test_index metrics
 

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -160,7 +160,7 @@ let pipeline ~config ~ocluster ~conninfo repository =
   let* () = p |> github_set_status ~repository in
   Current.ignore_value p
 
-let github_repositories repo =
+let github_repositories ~config repo =
   let* refs =
     Current.component "Get PRs"
     |> let> api, repo = repo in
@@ -185,8 +185,14 @@ let github_repositories repo =
       | `Ref branch when branch = default_branch ->
           repository ~branch:default_branch_name ~labels:[] () :: lst
       | `PR pr ->
-          repository ~title:pr.title ~pull_number:pr.id ~labels:pr.labels ()
-          :: lst
+          let repository =
+            repository ~title:pr.title ~pull_number:pr.id ~labels:pr.labels ()
+          in
+          if List.exists
+               (Config.must_benchmark repository)
+               (Config.find config repository)
+          then repository :: lst
+          else lst
       | _ -> lst)
     ref_map []
 
@@ -205,7 +211,7 @@ let filter_stale_repositories repos =
       | _ -> None)
     repos
 
-let repositories = function
+let repositories ~config = function
   | Source.Local path ->
       let local = Git.Local.v path in
       let name = Fpath.basename path in
@@ -227,7 +233,7 @@ let repositories = function
       let token = token |> Util.read_fpath |> String.trim in
       let api = Current_github.Api.of_oauth ~token ~webhook_secret in
       let repo = Current.return (api, repo) in
-      github_repositories repo
+      github_repositories ~config repo
   | Github_app app ->
       let+ repos =
         Github.App.installations app
@@ -236,12 +242,12 @@ let repositories = function
            repos
            |> Current.list_map ~collapse_key:"repo"
                 (module Github.Api.Repo)
-                github_repositories
+                (github_repositories ~config)
       in
       List.concat (List.concat repos)
 
-let repositories sources =
-  let repos = Current.list_seq (List.map repositories sources) in
+let repositories ~config sources =
+  let repos = Current.list_seq (List.map (repositories ~config) sources) in
   Current.map List.concat repos
 
 let string_of_repositories repos =
@@ -258,7 +264,7 @@ let pull_requests_from_repositories repos =
     repos
 
 let process_pipeline ~config ~ocluster ~conninfo ~sources () =
-  let repos = repositories sources in
+  let repos = repositories ~config sources in
   let fresh_repos = Current.map filter_stale_repositories repos in
   let+ () =
     let+ open_pulls = Current.map pull_requests_from_repositories repos in

--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -196,7 +196,8 @@ let github_repositories ~config repo =
          the repo's configuration. *)
       | `PR pr ->
           let repository =
-            repository ~title:pr.title ~pull_number:pr.id ~labels:pr.labels ()
+            repository ~title:pr.title ~pull_number:pr.id ~pull_base:pr.base
+              ~labels:pr.labels ()
           in
           if List.exists
                (Config.must_benchmark_pull repository)

--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -5,6 +5,7 @@ type t = {
   commit : Current_git.Commit_id.t;
   commit_message : string option;
   pull_number : int option;
+  pull_base : string option;
   branch : string option;
   github_head : Current_github.Api.Commit.t option;
   github_api : Current_github.Api.t option;
@@ -17,7 +18,7 @@ let default_src ?src commit =
   | None -> Current_git.fetch (Current.return commit)
   | Some src -> src
 
-let v ~owner ~name ?src ~commit ?commit_message ?pull_number ?branch
+let v ~owner ~name ?src ~commit ?commit_message ?pull_number ?pull_base ?branch
     ?github_head ?github_api ?title ~labels () =
   {
     owner;
@@ -25,6 +26,7 @@ let v ~owner ~name ?src ~commit ?commit_message ?pull_number ?branch
     commit;
     commit_message;
     pull_number;
+    pull_base;
     branch;
     github_head;
     github_api;
@@ -40,6 +42,7 @@ let commit t = t.commit
 let commit_message t = t.commit_message
 let commit_hash t = Current_git.Commit_id.hash t.commit
 let pull_number t = t.pull_number
+let pull_base t = t.pull_base
 let title t = t.title
 let labels t = t.labels
 let branch t = t.branch

--- a/pipeline/lib/storage.ml
+++ b/pipeline/lib/storage.ml
@@ -9,6 +9,7 @@ let setup_metadata ~repository ~worker ~docker_image
   in
   let branch = Db_util.(option string) (Repository.branch repository) in
   let pull_number = Db_util.(option int) (Repository.pull_number repository) in
+  let pull_base = Db_util.(option string) (Repository.pull_base repository) in
   let title = Db_util.(option string) (Repository.title repository) in
   let worker = Db_util.string worker in
   let docker_image = Db_util.string docker_image in
@@ -21,8 +22,8 @@ let setup_metadata ~repository ~worker ~docker_image
     *)
     Fmt.str
       {|INSERT INTO benchmark_metadata
-          (run_at, repo_id, commit, commit_message, branch, pull_number, pr_title, worker, docker_image)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+          (run_at, repo_id, commit, commit_message, branch, pull_number, pull_base, pr_title, worker, docker_image)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT(repo_id, commit, worker, docker_image)
         DO UPDATE
         SET build_job_id = NULL,
@@ -33,8 +34,8 @@ let setup_metadata ~repository ~worker ~docker_image
             reason = NULL
         RETURNING id;
       |}
-      run_at repo_id commit commit_message branch pull_number title worker
-      docker_image
+      run_at repo_id commit commit_message branch pull_number pull_base title
+      worker docker_image
   in
   let result = db#exec query in
   match result#get_all with

--- a/pipeline/tests/api_test.ml
+++ b/pipeline/tests/api_test.ml
@@ -91,12 +91,13 @@ let empty_benchmarks =
         (fun ?expect query ->
           let expected =
             "INSERT INTO benchmark_metadata (run_at, repo_id, commit, \
-             commit_message, branch, pull_number, pr_title, worker, \
+             commit_message, branch, pull_number, pull_base, pr_title, worker, \
              docker_image) VALUES (to_timestamp(XXX), 'myowner/myrepo', \
-             'abcd12345', NULL, 'main', NULL, NULL, 'remote', 'external') ON \
-             CONFLICT(repo_id, commit, worker, docker_image) DO UPDATE SET \
-             build_job_id = NULL, run_job_id = NULL, failed = false, cancelled \
-             = false, success = false, reason = NULL RETURNING id;"
+             'abcd12345', NULL, 'main', NULL, NULL, NULL, 'remote', \
+             'external') ON CONFLICT(repo_id, commit, worker, docker_image) DO \
+             UPDATE SET build_job_id = NULL, run_job_id = NULL, failed = \
+             false, cancelled = false, success = false, reason = NULL \
+             RETURNING id;"
           in
           Alcotest.(check string) "setup metadata" expected query;
           assert (expect = None);


### PR DESCRIPTION
Previously, we only ran the benchmarks on the default branch of a repository, apart from the pull requests. This PR adds support to run benchmarks on multiple branches of a repository, not just the default branch.

NOTE: This also includes the change in #428. That PR can either be merged before this one, or simply closed, in favor of this.

Closes #426 