### PR TITLE
Include the base branch path in pull URLs

### DIFF
--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -62,9 +62,9 @@ let to_string t =
 
 let to_path t =
   let pr =
-    match t.pull_number with
-    | None -> ""
-    | Some pr -> "/pull/" ^ string_of_int pr
+    match (t.pull_number, t.pull_base) with
+    | Some pr, Some base -> "/pull/" ^ string_of_int pr ^ "/base/" ^ base
+    | _ -> ""
   in
   info t ^ pr
 

--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -70,13 +70,9 @@ let to_path t =
 
 let frontend_url () = Sys.getenv "OCAML_BENCH_FRONTEND_URL"
 
-(* $server/$repo_owner/$repo_name/pull/$pull_number *)
-let commit_status_url { owner; name; pull_number; _ } =
-  let uri_end =
-    match pull_number with
-    | None -> "/" ^ owner ^ "/" ^ name
-    | Some number -> "/" ^ owner ^ "/" ^ name ^ "/pull/" ^ string_of_int number
-  in
+(* $server/$repo_owner/$repo_name/pull/$pull_number/base/$pull_base *)
+let commit_status_url repo =
+  let uri_end = to_path repo in
   Uri.of_string (frontend_url () ^ uri_end)
 
 let compare a b =


### PR DESCRIPTION
a2bc44e2b45638bf9616705ae856855d639bcece changed the URL path to include the name of the base branch against a pull-request has been opened. This commit fixes the URLs for pulls shared in Slack notifications.

Also, re-use code from `to_path` in `github_status_url` function. Fixes #435.