### PR TITLE
Fix the github-app.sh script that allows locally testing with a GitHub app

### DIFF
--- a/pipeline/dev/github-app.sh
+++ b/pipeline/dev/github-app.sh
@@ -4,7 +4,7 @@ set -eu
 
 ngrok authtoken "$OCAML_BENCH_NGROK_AUTH"
 
-ngrok http 8081 --log=stdout > /tmp/ngrok.log &
+ngrok http 8081 --log=stdout | tee /tmp/ngrok.log &
 
 URL=$(tail -F /tmp/ngrok.log | grep -m 1 -o -E 'https://[^ ]*.ngrok.*$')
 
@@ -12,7 +12,6 @@ WEBHOOK="${URL}/webhooks/github"
 
 SECRET=$(cat "/mnt/environments/$OCAML_BENCH_GITHUB_WEBHOOK_SECRET_FILE")
 
-JWT=$(dune exec --root=. --display=quiet dev/jwt.exe "$OCAML_BENCH_GITHUB_APP_ID" "/mnt/environments/$OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE")
 
 curl \
   -X PATCH \

--- a/pipeline/dev/github-app.sh
+++ b/pipeline/dev/github-app.sh
@@ -6,7 +6,7 @@ ngrok authtoken "$OCAML_BENCH_NGROK_AUTH"
 
 ngrok http 8081 --log=stdout > /tmp/ngrok.log &
 
-URL=$(tail -F /tmp/ngrok.log | grep -m 1 -o -E 'https://[^ ]*.ngrok.io$')
+URL=$(tail -F /tmp/ngrok.log | grep -m 1 -o -E 'https://[^ ]*.ngrok.*$')
 
 WEBHOOK="${URL}/webhooks/github"
 

--- a/pipeline/reload.sh
+++ b/pipeline/reload.sh
@@ -3,6 +3,15 @@ set -eu
 
 cd /mnt/project
 
+. /mnt/environments/development.env
+
+# We run `dune exec dev/jwt.exe` outside the `github-app.sh` script to avoid
+# running into issues with the `_build/.lock` being held by the main dune exec
+# command being run in the watch mode.
+JWT=$(dune exec --root=. --display=quiet dev/jwt.exe "$OCAML_BENCH_GITHUB_APP_ID" "/mnt/environments/$OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE")
+
+export JWT
+
 ./dev/github-app.sh &
 
 dune exec --watch bin/main.exe -- "$@"


### PR DESCRIPTION
This PR fixes a couple of things that were broken which broke the local dev workflow with a test GitHub app.  

1) ngrok added more domain names to their list of domains, but we looked only for ngrok.io
2) `dune exec` cannot be run in a project, after a `dune exec --watch` has already started.

The commit messages have more explanations on the bugs and the fixes.