### PR TITLE
Run the github-app.sh only if OCAML_BENCH_GITHUB_* env vars are set

### DIFF
--- a/pipeline/reload.sh
+++ b/pipeline/reload.sh
@@ -8,10 +8,10 @@ cd /mnt/project
 # We run `dune exec dev/jwt.exe` outside the `github-app.sh` script to avoid
 # running into issues with the `_build/.lock` being held by the main dune exec
 # command being run in the watch mode.
-JWT=$(dune exec --root=. --display=quiet dev/jwt.exe "$OCAML_BENCH_GITHUB_APP_ID" "/mnt/environments/$OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE")
-
-export JWT
-
-./dev/github-app.sh &
+if [[ -n "${OCAML_BENCH_GITHUB_APP_ID}" && -n "${OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE}" ]]; then
+    JWT=$(dune exec --root=. --display=quiet dev/jwt.exe "$OCAML_BENCH_GITHUB_APP_ID" "/mnt/environments/$OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE")
+    export JWT
+    ./dev/github-app.sh &
+fi
 
 dune exec --watch bin/main.exe -- "$@"


### PR DESCRIPTION
Running `dune exec dev/jwt.exe` crashes with a cryptic `Fatal error: exception Sys_error("Value too large for defined data type")` when development.env has empty values for the OCAML_BENCH_GITHUB_* environment variables. This commit ensures that we try to run this command and the `./dev/github-app.sh` script only when a couple of these variables are set.