### PR TITLE
Benchmark names with spaces are not viewable in the UI

### DIFF
--- a/frontend/src/App.res
+++ b/frontend/src/App.res
@@ -37,7 +37,7 @@ let makeGetBenchmarksVariables = (
     isMaster,
     worker,
     dockerImage,
-    benchmarkName: Belt.Option.getWithDefault(benchmarkName, defaultBenchmarkName),
+    benchmarkName: Js.Global.decodeURIComponent(Belt.Option.getWithDefault(benchmarkName, defaultBenchmarkName)),
     startDate,
     endDate,
     comparisonLimit,


### PR DESCRIPTION
When a benchmark name contains a space, the name is passed as a encoded string, which causes the GraphQL query to fail.  This commit ensures that the name is decoded before passing it to the GraphQL query.

Closes #457