### PR TITLE
Improve the label and link of the current-bench check in the list of checks for a PR

### DIFF
--- a/pipeline/lib/repository.ml
+++ b/pipeline/lib/repository.ml
@@ -70,11 +70,6 @@ let to_path t =
 
 let frontend_url () = Sys.getenv "OCAML_BENCH_FRONTEND_URL"
 
-(* $server/$repo_owner/$repo_name/pull/$pull_number/base/$pull_base *)
-let commit_status_url repo =
-  let uri_end = to_path repo in
-  Uri.of_string (frontend_url () ^ "/" ^ uri_end)
-
 let compare a b =
   let cmp =
     Stdlib.compare

--- a/pipeline/reload.sh
+++ b/pipeline/reload.sh
@@ -12,6 +12,8 @@ if [[ -n "${OCAML_BENCH_GITHUB_APP_ID}" && -n "${OCAML_BENCH_GITHUB_PRIVATE_KEY_
     JWT=$(dune exec --root=. --display=quiet dev/jwt.exe "$OCAML_BENCH_GITHUB_APP_ID" "/mnt/environments/$OCAML_BENCH_GITHUB_PRIVATE_KEY_FILE")
     export JWT
     ./dev/github-app.sh &
+else
+    echo "NOTE: Not starting the development GitHub App since configuration is missing!"
 fi
 
 dune exec --watch bin/main.exe -- "$@"


### PR DESCRIPTION
When a repo has multiple configurations for different benchmark runs, the checks list previously displayed only entry which could be confusing for the users especially when one of the runs was much longer than the other. This PR fixes the number of entries to match with the number of configurations for a repo, and fixes the links to go to the correct page.

Closes #453

NOTE: The PR has an unrelated commit that improves #461 to print a log message when the local GitHub app isn't running.