### PR TITLE
Fix broken GitHub notifications for changed metrics

### DIFF
--- a/pipeline/lib/pipeline.ml
+++ b/pipeline/lib/pipeline.ml
@@ -141,7 +141,7 @@ let pipeline ~config ~ocluster ~conninfo ~repository env =
   and+ () = Config.slack_log ~config ~key:(key ^ " jsons") @@ output
   and+ _ =
     Metric.notify_metric_changes ~conninfo ~repository ~worker ~docker_image
-      ~config output
+      ~env output
   in
   ()
 


### PR DESCRIPTION
The code to figure out whether or not we should send a notification was unnecessarily complex and buggy.  This commit simplifies the code, and fixes the bug which caused notifications to be not sent for repositories which didn't have a dockerfile configured in the `.conf` file, but had the default dockerfile (`bench.Dockerfile`) present in the repository.