### PR TITLE
Add link to report issues with the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ section.
 If you want to run this project locally or want to contribute to improving
 current-bench, see [HACKING.md](HACKING.md)
 
+Please report any issues with the [benchmarking service](https://bench.ci.dev) at [ocaml/infrastructure](https://github.com/ocaml/infrastructure).
+
 ## Enroll your repository
 
 `current-bench` uses a [GitHub


### PR DESCRIPTION
Draft PR pending move of the service to bench.ci.dev

Directs to report issues with the service at ocaml/infrastructure.