### PR TITLE
Allow specifying a label to send GitHub notifications to PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ listed below, or other customization, please reach out to the maintainers.
 - Run the benchmarks only on PRs with a specific label (`if_label`)
 - Specify build-args when building the docker image (`build_args`)
 - Run benchmarks on more than one long-running branches (`branches`)
-- Post GitHub comments with the build results when there's a significant change in the results (`notify_github`)
+- Post GitHub comments with the build results when there's a significant change
+  in the results (`notify_github`).  The config value can also specify a label,
+  which ensures that only those PRs with this label get notified with the
+  benchmark results.  NOTE: The PR label cannot be added while the benchmark
+  run has started.  To trigger a run, where the results are posted to the PR,
+  you'll have to trigger a new run by (force) pushing to the branch.
 
 ## Ensuring we can run your benchmarks
 To be able to run your benchmarks, current-bench assumes certain things about your repo:

--- a/environments/development.conf
+++ b/environments/development.conf
@@ -3,13 +3,14 @@
     {
       "name": "local/test",
       "worker": "autumn",
-      "image": "ocaml/opam:debian-11-ocaml-4.14"
+      "image": "ocaml/opam:debian-11-ocaml-4.14",
+      "notify_github": false
     },
     {
       "name": "local/test",
       "worker": "autumn",
       "image": "ocaml/opam:debian-11-ocaml-4.13",
-      "notify_github": true
+      "notify_github": "benchmark"
     }
   ],
   "api_tokens": [

--- a/pipeline/lib/config.ml
+++ b/pipeline/lib/config.ml
@@ -5,6 +5,20 @@ module Images = Map.Make (String)
 let default_worker = "autumn"
 let default_docker = "ocaml/opam:debian-ocaml-5.0"
 
+type notify_option = Bool of bool | Label of string
+
+let default_notify_option = Bool false
+
+let notify_option_of_yojson json =
+  match json with
+  | `Bool b -> Ok (Bool b)
+  | `String label -> Ok (Label label)
+  | _ -> Error "Invalid JSON format for notify_option"
+
+let notify_option_to_yojson = function
+  | Bool b -> `Bool b
+  | Label label -> `String label
+
 type repo = {
   name : string;
   worker : string; [@default default_worker]
@@ -12,7 +26,7 @@ type repo = {
   dockerfile : string option; [@default None]
   schedule : string option; [@default None]
   build_args : string list; [@default []]
-  notify_github : bool; [@default false]
+  notify_github : notify_option; [@default default_notify_option]
   if_label : string option; [@default None]
   branches : string list; [@default []]
   bench_repo : string option; [@default None]
@@ -98,7 +112,7 @@ let default name =
     dockerfile = None;
     schedule = None;
     build_args = [];
-    notify_github = false;
+    notify_github = default_notify_option;
     if_label = None;
     branches = [];
     bench_repo = None;


### PR DESCRIPTION
This commit adds a config option to specify a label to send the results of benchmark runs as comments on GitHub PRs.