### PR TITLE
Be aggressive about removing all intermediate containers

### DIFF
--- a/worker/cb_worker.ml
+++ b/worker/cb_worker.ml
@@ -156,7 +156,7 @@ let docker_build ~switch ~log ~src ~options ~dockerpath ~iid_file =
   let args =
     List.concat_map (fun x -> [ "--build-arg"; x ]) build_args
     @ (if squash then [ "--squash" ] else [])
-    @ [ "--pull"; "--iidfile"; iid_file; "-f"; dockerpath; src ]
+    @ [ "--pull"; "--force-rm"; "--iidfile"; iid_file; "-f"; dockerpath; src ]
   in
   Process.check_call ~label:"docker-build" ~switch ~log
     ("docker" :: "build" :: args)


### PR DESCRIPTION
Autumn has been having space issues (and has been running out of inodes). It's not clear what is causing this, since docker system prune doesn't seem to help. We already run `docker run` with `--rm` argument. This commit changes the build also to remove intermediate containers in case of build failures.