### PR TITLE
Bench old commits

### DIFF
--- a/current-bench.opam
+++ b/current-bench.opam
@@ -70,7 +70,7 @@ pin-depends: [
   # Using the changes in ocurrent/ocurrent/pull/421, remove the pin on next release (> 0.6.4)
   ["current_github.0.6.4" "git+https://github.com/ocurrent/ocurrent.git#32561e1f2b9cc387d098e0ee918cd6bd2ccd1d3b"]
   # Using the changes in ocurrent/ocurrent/pull/442, remove the pin on next release (> 0.6.4)
-  ["current_git.0.6.4"    "git+https://github.com/ElectreAAS/ocurrent.git#21e7007e2897d44535e2729b42c80dc1280c6fb1"]
+  ["current_git.0.6.4"    "git+https://github.com/ocurrent/ocurrent.git#8e0b9d4bb348b13df8696fe63feba303b9a476fd"]
 ]
 
 # System dependencies fail to install on these platforms

--- a/current-bench.opam
+++ b/current-bench.opam
@@ -66,9 +66,11 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/current-bench.git"
 pin-depends: [
+  # When modifying the pins in this file, don't forget to also modify pipeline/pipeline.opam
   # Using the changes in ocurrent/ocurrent/pull/421, remove the pin on next release (> 0.6.4)
-  # When modifying this pin, don't forget to also modify pipeline/pipeline.opam
   ["current_github.0.6.4" "git+https://github.com/ocurrent/ocurrent.git#32561e1f2b9cc387d098e0ee918cd6bd2ccd1d3b"]
+  # Using the changes in ocurrent/ocurrent/pull/442, remove the pin on next release (> 0.6.4)
+  ["current_git.0.6.4"    "git+https://github.com/ElectreAAS/ocurrent.git#21e7007e2897d44535e2729b42c80dc1280c6fb1"]
 ]
 
 # System dependencies fail to install on these platforms

--- a/current-bench.opam.template
+++ b/current-bench.opam.template
@@ -1,7 +1,9 @@
 pin-depends: [
+  # When modifying the pins in this file, don't forget to also modify pipeline/pipeline.opam
   # Using the changes in ocurrent/ocurrent/pull/421, remove the pin on next release (> 0.6.4)
-  # When modifying this pin, don't forget to also modify pipeline/pipeline.opam
   ["current_github.0.6.4" "git+https://github.com/ocurrent/ocurrent.git#32561e1f2b9cc387d098e0ee918cd6bd2ccd1d3b"]
+  # Using the changes in ocurrent/ocurrent/pull/442, remove the pin on next release (> 0.6.4)
+  ["current_git.0.6.4"    "git+https://github.com/ElectreAAS/ocurrent.git#21e7007e2897d44535e2729b42c80dc1280c6fb1"]
 ]
 
 # System dependencies fail to install on these platforms

--- a/current-bench.opam.template
+++ b/current-bench.opam.template
@@ -3,7 +3,7 @@ pin-depends: [
   # Using the changes in ocurrent/ocurrent/pull/421, remove the pin on next release (> 0.6.4)
   ["current_github.0.6.4" "git+https://github.com/ocurrent/ocurrent.git#32561e1f2b9cc387d098e0ee918cd6bd2ccd1d3b"]
   # Using the changes in ocurrent/ocurrent/pull/442, remove the pin on next release (> 0.6.4)
-  ["current_git.0.6.4"    "git+https://github.com/ElectreAAS/ocurrent.git#21e7007e2897d44535e2729b42c80dc1280c6fb1"]
+  ["current_git.0.6.4"    "git+https://github.com/ocurrent/ocurrent.git#8e0b9d4bb348b13df8696fe63feba303b9a476fd"]
 ]
 
 # System dependencies fail to install on these platforms

--- a/pipeline/lib/commits.ml
+++ b/pipeline/lib/commits.ml
@@ -1,4 +1,9 @@
+module Comm = Current_git.Commit
+module Comm_id = Current_git.Commit_id
 module Db = Models.Benchmark.Db
+
+(** Maximum number of commits we'll return with [get_history]. *)
+let runaway_limit = 20
 
 module Get_commits = struct
   type t = string
@@ -6,72 +11,80 @@ module Get_commits = struct
   let id = "commit-history"
 
   module Key = struct
-    type t = { commit : Current_git.Commit.t; repo_id : string }
+    type t = { commit : Comm.t; repo_id : string }
 
     let digest { commit; repo_id } =
-      Fmt.str "%s/%s" repo_id (Current_git.Commit.marshal commit)
+      Fmt.str "%s/%s" repo_id (Comm.marshal commit)
   end
 
   module Value = struct
-    type v = { commit : Current_git.Commit_id.t; commit_message : string }
-    type t = v list
+    type v = { hash : string; title : string; commit_message : string }
+    [@@deriving yojson]
 
-    let string_of_v { commit; commit_message } =
-      Fmt.str "%S: %s\n" commit_message (Current_git.Commit_id.digest commit)
+    type t = v list [@@deriving yojson]
 
-    let marshal t = String.concat "\n" (List.map string_of_v t)
+    let marshal t = t |> to_yojson |> Yojson.Safe.to_string
 
-    let unmarshal str =
-      let lines = String.split_on_char '\n' str in
-      List.map
-        (fun line ->
-          Scanf.sscanf line "\"%s\": %s %s %s"
-            (fun commit_message repo gref hash ->
-              {
-                commit = Current_git.Commit_id.v ~repo ~gref ~hash;
-                commit_message;
-              }))
-        lines
-
-    let pp t = print_endline (marshal t)
+    let unmarshal t =
+      match Yojson.Safe.from_string t |> of_yojson with
+      | Ppx_deriving_yojson_runtime.Result.Ok x -> x
+      | Ppx_deriving_yojson_runtime.Result.Error msg ->
+          Fmt.failwith "Unmarshalling Commit.Value.t failed with message: %s"
+            msg
   end
 
   open Lwt.Syntax
 
   let hash_to_parent dir t =
+    (* asks git what the commit before `t` is. git answers in the format:
+       hashhashhashhashhashhash title
+       rest of the
+       commit message
+    *)
     let cmd =
       [|
         "git";
         "-C";
         dir;
         "rev-list";
-        "--format=oneline";
+        "--no-commit-header";
+        "--ignore-missing";
+        "--format=%H %B";
         "-1";
-        Fmt.str "\"%s^\"" t;
+        t ^ "^";
       |]
     in
-    let+ line = Lwt_process.pread ("", cmd) in
-    Scanf.sscanf line "%s %s@\n" (fun hash msg -> (hash, msg))
+    let+ lines = Lwt_process.pread ("git", cmd) in
+    if lines = ""
+    then None
+    else
+      (* In below format, `\003` is the End Of Text codepoint, and is assumed
+         to never be in the commit message. *)
+      Scanf.sscanf lines "%s %s@\n %s@\003" (fun hash title msg ->
+          Some (hash, title, String.trim msg))
 
   let build conninfo job { Key.commit; repo_id } =
     let* () = Current.Job.start job ~level:Current.Level.Average in
-    Current_git.with_checkout ~job commit @@ fun dir ->
-    let dir = Fpath.to_string dir in
-    let rec loop hash acc =
-      if Db.commit_exists ~conninfo ~repo_id ~hash
-      then (
-        Value.pp acc;
-        Lwt.return (Ok acc))
-      else
-        let* hash, msg = hash_to_parent dir hash in
-        let parent = Current_git.Commit_id.v ~repo:dir ~hash ~gref:hash in
-        loop hash ({ Value.commit = parent; commit_message = msg } :: acc)
-    in
-    loop (Current_git.Commit.hash commit) []
+    if not @@ Db.repo_exists ~conninfo ~repo_id
+    then Lwt.return (Ok [])
+    else
+      Current_git.with_checkout ~job commit @@ fun dir ->
+      let dir = Fpath.to_string dir in
+      let rec loop i hash acc =
+        if i >= runaway_limit
+        then Lwt.return (Ok acc)
+        else
+          let* parent_opt = hash_to_parent dir hash in
+          match parent_opt with
+          | Some (hash, title, commit_message)
+            when not @@ Db.commit_exists ~conninfo ~repo_id ~hash ->
+              loop (i + 1) hash ({ Value.hash; title; commit_message } :: acc)
+          | _ -> Lwt.return (Ok acc)
+      in
+      loop 0 (Comm.hash commit) []
 
   let pp f { Key.commit; repo_id } =
-    Fmt.pf f "@[<v2>git commit history %s/%a@]" repo_id Current_git.Commit.pp
-      commit
+    Fmt.pf f "@[<v2>git commit history %s/%a@]" repo_id Comm.pp commit
 
   let auto_cancel = true
 end
@@ -79,14 +92,32 @@ end
 module Cache = Current_cache.Make (Get_commits)
 open Current.Syntax
 
-let get_history conninfo repo =
-  let commits =
+(** From one [Repository.t] (a repo at a specific commit), get the list of
+    commits in that repo that need to be benchmarked. If that repo has never
+    been benchmarked before (new addition to the service), we only bench the
+    last commit. As a safety measure for now, we only bench [runaway_limit]
+    commits at a maximum. *)
+let get_history ~conninfo repo =
+  let repo_id = Repository.info repo in
+  let+ commits =
     Current.component "get-history"
     |> let> commit = Repository.src repo in
-       let repo_id = Repository.info repo in
        Cache.get conninfo { Get_commits.Key.commit; repo_id }
   in
-  Current.map
-    (List.map (fun { Get_commits.Value.commit; commit_message } ->
-         { repo with commit; commit_message = Some commit_message }))
-    commits
+  repo
+  :: List.map
+       (fun { Get_commits.Value.hash; title; commit_message } ->
+         let commit = Comm_id.v ~repo:repo_id ~hash ~gref:hash in
+         let src =
+           let+ src = repo.src in
+           let repo = Comm.repo src in
+           Comm.v ~repo ~id:commit
+         in
+         {
+           repo with
+           src;
+           commit;
+           title = Some title;
+           commit_message = Some commit_message;
+         })
+       commits

--- a/pipeline/lib/commits.ml
+++ b/pipeline/lib/commits.ml
@@ -1,0 +1,98 @@
+module Db = Models.Benchmark.Db
+
+module Get_commits = struct
+  type t = string
+
+  let id = "commit-history"
+
+  module Key = struct
+    type t = { commit : Current_git.Commit.t; repo_id : string }
+
+    let digest { commit; repo_id } =
+      Fmt.str "%s/%s" repo_id (Current_git.Commit.marshal commit)
+  end
+
+  module Value = struct
+    type v = {
+      commit : Current_git.Commit_id.t;
+      commit_message : string option;
+    }
+
+    type t = v list
+
+    let string_of_v { commit; commit_message } =
+      Fmt.str "%S: %s\n"
+        (Option.value commit_message ~default:"None")
+        (Current_git.Commit_id.digest commit)
+
+    let marshal t = String.concat "\n" (List.map string_of_v t)
+
+    let unmarshal str =
+      let lines = String.split_on_char '\n' str in
+      List.map
+        (fun line ->
+          Scanf.sscanf line "%s: %s %s %s" (fun commit_message repo gref hash ->
+              {
+                commit = Current_git.Commit_id.v ~repo ~gref ~hash;
+                commit_message =
+                  (if commit_message = {|"None"|}
+                  then None
+                  else Some commit_message);
+              }))
+        lines
+
+    let pp t = print_endline (marshal t)
+  end
+
+  open Lwt.Syntax
+  open Lwt.Infix
+
+  let hash_to_parent dir t =
+    let cmd =
+      [| "git"; "-C"; dir; "rev-parse"; "--revs-only"; Fmt.str "%s^" t |]
+    in
+    (* FIXME: add commit_message *)
+    Lwt_process.pread ("", cmd) >|= String.trim
+
+  let build conninfo job { Key.commit; repo_id } =
+    Current.Job.start job ~level:Current.Level.Average >>= fun () ->
+    Current_git.with_checkout ~job commit @@ fun dir ->
+    let dir = Fpath.to_string dir in
+    let rec loop hash acc =
+      if Db.commit_exists ~conninfo ~repo_id ~hash
+      then (
+        Value.pp acc;
+        Lwt.return (Ok acc))
+      else
+        let* hash = hash_to_parent dir hash in
+        let parent = Current_git.Commit_id.v ~repo:dir ~hash ~gref:hash in
+        loop hash
+          ({
+             Value.commit = parent;
+             commit_message = (* FIXME: add commit message here *) None;
+           }
+          :: acc)
+    in
+    loop (Current_git.Commit.hash commit) []
+
+  let pp f { Key.commit; repo_id } =
+    Fmt.pf f "@[<v2>git commit history %s/%a@]" repo_id Current_git.Commit.pp
+      commit
+
+  let auto_cancel = true
+end
+
+module Cache = Current_cache.Make (Get_commits)
+open Current.Syntax
+
+let get_history conninfo repo =
+  let commits =
+    Current.component "get-history"
+    |> let> commit = Repository.src repo in
+       let repo_id = Repository.info repo in
+       Cache.get conninfo { Get_commits.Key.commit; repo_id }
+  in
+  Current.map
+    (List.map (fun { Get_commits.Value.commit; commit_message } ->
+         { repo with commit; commit_message }))
+    commits

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -37,5 +37,8 @@ module Benchmark : sig
 
     val exists :
       conninfo:Db_util.t -> env:Custom_dockerfile.Env.t -> Repository.t -> bool
+
+    val commit_exists :
+      conninfo:Db_util.t -> repo_id:string -> hash:string -> bool
   end
 end

--- a/pipeline/lib/models.mli
+++ b/pipeline/lib/models.mli
@@ -40,5 +40,7 @@ module Benchmark : sig
 
     val commit_exists :
       conninfo:Db_util.t -> repo_id:string -> hash:string -> bool
+
+    val repo_exists : conninfo:Db_util.t -> repo_id:string -> bool
   end
 end

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -47,10 +47,13 @@ depends: [
   "odoc" {with-doc}
 ]
 pin-depends: [
+  # When modifying the pins in this file, don't forget to also modify pipeline/pipeline.opam
   # Using the changes in ocurrent/ocurrent/pull/421, remove the pin on next release (> 0.6.4)
-  # When modifying this pin, don't forget to also modify ../current-bench.opam.template
   ["current_github.0.6.4" "git+https://github.com/ocurrent/ocurrent.git#32561e1f2b9cc387d098e0ee918cd6bd2ccd1d3b"]
+  # Using the changes in ocurrent/ocurrent/pull/442, remove the pin on next release (> 0.6.4)
+  ["current_git.0.6.4"    "git+https://github.com/ElectreAAS/ocurrent.git#21e7007e2897d44535e2729b42c80dc1280c6fb1"]
 ]
+
 build: [
   ["dune" "subst"] {dev}
   [

--- a/pipeline/pipeline.opam
+++ b/pipeline/pipeline.opam
@@ -51,7 +51,7 @@ pin-depends: [
   # Using the changes in ocurrent/ocurrent/pull/421, remove the pin on next release (> 0.6.4)
   ["current_github.0.6.4" "git+https://github.com/ocurrent/ocurrent.git#32561e1f2b9cc387d098e0ee918cd6bd2ccd1d3b"]
   # Using the changes in ocurrent/ocurrent/pull/442, remove the pin on next release (> 0.6.4)
-  ["current_git.0.6.4"    "git+https://github.com/ElectreAAS/ocurrent.git#21e7007e2897d44535e2729b42c80dc1280c6fb1"]
+  ["current_git.0.6.4"    "git+https://github.com/ocurrent/ocurrent.git#8e0b9d4bb348b13df8696fe63feba303b9a476fd"]
 ]
 
 build: [


### PR DESCRIPTION
Fixes #379.
- `pipeline/lib/commits.ml` contains the important part: the actual git command to run to traverse the commit history.
- `pipeline/libs/models.ml[i]` contains the necessary two new functions that query the database, to make sure we don't benchmark twice the same commit.

~~Note: This PR requires some changes to the API of ocurrent (namely this PR: https://github.com/ocurrent/ocurrent/pull/442), and hence is in draft mode to make sure it doesn't get merged before the PR on ocurrent is properly reviewed.
It is, however, ready to be reviewed in the current-bench context. The API changes in ocurrent are trivials from our point of view.~~

Edit: ocurrent/ocurrent#442 has been merged, this is ready for review
