### PR TITLE
Use omigrate `setup` in the pipeline entrypoint script

### DIFF
--- a/pipeline/entrypoint.sh
+++ b/pipeline/entrypoint.sh
@@ -30,6 +30,6 @@ chmod -R a+rw /app/capnp-secrets
 # Run migrations
 set -eu
 echo "Running migrations..."
-omigrate up --verbose --source=/app/db/migrations --database="postgresql://docker:docker@db:5432/${OCAML_BENCH_DB_PASSWORD}"
+omigrate setup --verbose --source=/app/db/migrations --database="postgresql://docker:docker@db:5432/${OCAML_BENCH_DB_PASSWORD}"
 
 exec "$@"


### PR DESCRIPTION
`omigrate setup` ensures that the database exists and the version table of schema migrations exists, before running `up`, which runs all the migrations that have not yet been run. Using `setup` works better in cases where the database has not yet been setup, and works the same in cases when running with an existing DB.