### PR TITLE
Forbid bugged version 2.1.1 of yojson to fix tests

### DIFF
--- a/current-bench.opam
+++ b/current-bench.opam
@@ -44,7 +44,7 @@ depends: [
   "rresult"
   "timere" {>= "0.5.0"}
   "timere-parse"
-  "yojson"
+  "yojson" {!= "2.1.1"}
   "alcotest" {with-test}
   "alcotest-lwt" {>= "1.0.0" & with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -71,7 +71,10 @@
   (timere
    (>= 0.5.0))
   timere-parse
-  yojson
+  ; yojson.2.1.1 is bugged in a minor way.
+  ; change into a lower bound when there is a new release
+  (yojson
+   (<> 2.1.1))
   (alcotest :with-test)
   (alcotest-lwt
    (and


### PR DESCRIPTION
The latest version of Yojson is bugged. See https://github.com/ocaml-community/yojson/issues/171 for details.
I added a version constraint to the main opam file so that the CI will pass, and there shouldn't be problems when `opam install . --deps-only` on a fresh clone.